### PR TITLE
rollback description to required dpc-sdp/tide_api:^1.2.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "drupal/webform": "^5.2"
     },
     "suggest": {
-        "dpc-sdp/tide_api:^1.2.9": "Set default value to jsonapi.settings readonly property"
+        "dpc-sdp/tide_api:^1.2.9": "Allows to use Drupal in headless mode"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
change back to what was.