### PR TITLE
[SDPA-3119] Added restricting content rating form access from BE for anonymous users.

### DIFF
--- a/tide_webform.module
+++ b/tide_webform.module
@@ -29,6 +29,12 @@ function tide_webform_config_ignore_settings_alter(array &$settings) {
 function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (!empty($form['#webform_id']) && $form['#webform_id'] == 'tide_webform_content_rating') {
     $form['#attached']['library'][] = 'tide_webform/content_rating';
+
+    // Restricting access for anonymous user from BE.
+    if (\Drupal::currentUser()->isAnonymous()) {
+      $form['#access'] = FALSE;
+      $form['#markup'] = t('Access Denied.');
+    }
   }
 
   if ($form_id == 'webform_ui_element_form') {


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-

### Changed

1.  Added a check in hook_form_alter to identify the anonymous users when they are on the content rating form.
2. Making access false on that form for anonymous users.

### Screenshots
The following screenshot shows the submission from the front end works, only the access is false from BE.
![Screen Shot 2019-10-22 at 2 25 57 pm](https://user-images.githubusercontent.com/20810541/67257525-21482400-f4d8-11e9-9ca6-6073458a24cd.png)

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
