### PR TITLE
[SDPA-3943] Added hook to update webform settings.

### DIFF
--- a/config/optional/webform.settings.yml
+++ b/config/optional/webform.settings.yml
@@ -131,6 +131,7 @@ element:
     webform_contact: webform_contact
     webform_custom_composite: webform_custom_composite
     webform_document_file: webform_document_file
+    webform_element: webform_element
     webform_email_confirm: webform_email_confirm
     webform_email_multiple: webform_email_multiple
     webform_entity_checkboxes: webform_entity_checkboxes

--- a/config/optional/webform.settings.yml
+++ b/config/optional/webform.settings.yml
@@ -1,0 +1,218 @@
+settings:
+  default_status: open
+  default_page_base_path: form
+  default_form_open_message: 'This form has not yet been opened to submissions.'
+  default_form_close_message: 'Sorry...This form is closed to new submissions.'
+  default_form_exception_message: 'Unable to display this webform. Please contact the site administrator.'
+  default_submit_button_label: Submit
+  default_reset_button_label: Reset
+  default_form_submit_once: false
+  default_form_confidential_message: 'This form is confidential. You must <a href="[site:login-url]/logout?destination=[current-page:url:relative]">Log out</a> to submit it.'
+  default_form_login_message: 'Please login to access this form.'
+  default_form_disable_back: false
+  default_form_submit_back: false
+  default_form_unsaved: false
+  default_form_novalidate: false
+  default_form_disable_inline_errors: false
+  default_form_required: false
+  default_form_required_label: 'Indicates required field'
+  default_form_details_toggle: true
+  form_classes: "container-inline clearfix\nform--inline clearfix\nmessages messages--error\nmessages messages--warning\nmessages messages--status\n"
+  button_classes: ''
+  default_wizard_prev_button_label: '< Previous Page'
+  default_wizard_next_button_label: 'Next Page >'
+  default_wizard_start_label: Start
+  default_wizard_confirmation_label: Complete
+  default_preview_next_button_label: Preview
+  default_preview_prev_button_label: '< Previous'
+  default_preview_label: Preview
+  default_preview_title: '[webform:title]: Preview'
+  default_preview_message: 'Please review your submission. Your submission is not complete until you press the "Submit" button!'
+  default_draft_button_label: 'Save Draft'
+  default_draft_saved_message: 'Submission saved. You may return to this form later and it will restore the current values.'
+  default_draft_loaded_message: 'A partially-completed form was found. Please complete the remaining portions.'
+  default_confirmation_message: 'New submission added to [webform:title].'
+  default_confirmation_back_label: 'Back to form'
+  default_submission_label: '[webform_submission:submitted-to]: Submission #[webform_submission:serial]'
+  default_submission_access_denied_message: 'Please login to access this submission.'
+  default_submission_exception_message: 'Unable to process this submission. Please contact the site administrator.'
+  default_submission_locked_message: 'This submission has been locked.'
+  default_submission_log: false
+  default_autofill_message: 'This submission has been autofilled with your previous submission.'
+  preview_classes: "messages messages--error\nmessages messages--warning\nmessages messages--status\n"
+  confirmation_classes: "messages messages--error\nmessages messages--warning\nmessages messages--status\n"
+  confirmation_back_classes: "button\n"
+  default_limit_total_message: 'No more submissions are permitted.'
+  default_limit_user_message: 'No more submissions are permitted.'
+  dialog: false
+  dialog_options:
+    narrow:
+      title: Narrow
+      width: 600
+    normal:
+      title: Normal
+      width: 800
+    wide:
+      title: Wide
+      width: 1000
+assets:
+  css: ''
+  javascript: ''
+handler:
+  excluded_handlers: {  }
+export:
+  exporter: delimited
+  multiple_delimiter: ;
+  header_format: label
+  header_prefix: true
+  header_prefix_label_delimiter: ': '
+  header_prefix_key_delimiter: __
+  composite_element_item_format: label
+  options_single_format: compact
+  options_multiple_format: compact
+  options_item_format: label
+  entity_reference_items:
+    - id
+    - title
+    - url
+  likert_answers_format: label
+  signature_format: status
+  delimiter: ','
+  excel: false
+  excluded_exporters: {  }
+batch:
+  default_batch_export_size: 500
+  default_batch_update_size: 500
+  default_batch_delete_size: 500
+  default_batch_email_size: 500
+purge:
+  cron_size: 100
+element:
+  empty_message: '{Empty}'
+  allowed_tags: admin
+  wrapper_classes: "container-inline clearfix\nform--inline clearfix\nmessages messages--error\nmessages messages--warning\nmessages messages--status\n"
+  classes: "container-inline clearfix\nform--inline clearfix\nmessages messages--error\nmessages messages--warning\nmessages messages--status\n"
+  horizontal_rule_classes: "webform-horizontal-rule--solid\nwebform-horizontal-rule--dashed\nwebform-horizontal-rule--dotted\nwebform-horizontal-rule--gradient\nwebform-horizontal-rule--thin\nwebform-horizontal-rule--medium\nwebform-horizontal-rule--thick\nwebform-horizontal-rule--flaired\nwebform-horizontal-rule--glyph\n"
+  default_description_display: ''
+  default_more_title: More
+  default_section_title_tag: h2
+  default_empty_option: true
+  default_empty_option_required: ''
+  default_empty_option_optional: ''
+  default_icheck: ''
+  default_google_maps_api_key: ''
+  excluded_elements:
+    password: password
+    password_confirm: password_confirm
+    checkboxes: checkboxes
+    color: color
+    container: container
+    datelist: datelist
+    datetime: datetime
+    details: details
+    entity_autocomplete: entity_autocomplete
+    fieldset: fieldset
+    item: item
+    language_select: language_select
+    managed_file: managed_file
+    range: range
+    search: search
+    tableselect: tableselect
+    text_format: text_format
+    value: value
+    view: view
+    webform_address: webform_address
+    webform_audio_file: webform_audio_file
+    webform_autocomplete: webform_autocomplete
+    webform_checkboxes_other: webform_checkboxes_other
+    webform_codemirror: webform_codemirror
+    webform_computed_token: webform_computed_token
+    webform_computed_twig: webform_computed_twig
+    webform_contact: webform_contact
+    webform_custom_composite: webform_custom_composite
+    webform_document_file: webform_document_file
+    webform_email_confirm: webform_email_confirm
+    webform_email_multiple: webform_email_multiple
+    webform_entity_checkboxes: webform_entity_checkboxes
+    webform_entity_radios: webform_entity_radios
+    webform_entity_select: webform_entity_select
+    webform_flexbox: webform_flexbox
+    webform_image_file: webform_image_file
+    webform_likert: webform_likert
+    webform_link: webform_link
+    webform_location_places: webform_location_places
+    webform_mapping: webform_mapping
+    webform_message: webform_message
+    webform_more: webform_more
+    webform_name: webform_name
+    webform_radios_other: webform_radios_other
+    webform_rating: webform_rating
+    webform_same: webform_same
+    webform_scale: webform_scale
+    webform_section: webform_section
+    webform_select_other: webform_select_other
+    webform_signature: webform_signature
+    webform_table: webform_table
+    webform_table_row: webform_table_row
+    webform_table_sort: webform_table_sort
+    webform_tableselect_sort: webform_tableselect_sort
+    webform_telephone: webform_telephone
+    webform_term_checkboxes: webform_term_checkboxes
+    webform_terms_of_service: webform_terms_of_service
+    webform_time: webform_time
+    webform_variant: webform_variant
+    webform_video_file: webform_video_file
+    webform_wizard_page: webform_wizard_page
+html_editor:
+  disabled: false
+  format: ''
+  tidy: true
+file:
+  file_public: false
+  file_private_redirect: true
+  file_private_redirect_message: 'Please login to access the uploaded file.'
+  default_max_filesize: ''
+  default_managed_file_extensions: 'gif jpg png bmp eps tif pict psd txt rtf html odf pdf doc docx ppt pptx xls xlsx xml avi mov mp3 ogg wav bz2 dmg gz jar rar sit svg tar zip'
+  default_audio_file_extensions: 'mp3 ogg wav'
+  default_document_file_extensions: 'txt rtf pdf doc docx odt ppt pptx odp xls xlsx ods'
+  default_image_file_extensions: 'gif jpg png svg'
+  default_video_file_extensions: 'avi mov mp4 ogg wav webm'
+  make_unused_managed_files_temporary: true
+  delete_temporary_managed_files: true
+format: {  }
+mail:
+  default_to_mail: '[site:mail]'
+  default_from_mail: '[site:mail]'
+  default_from_name: '[site:name]'
+  default_reply_to: ''
+  default_return_path: ''
+  default_sender_mail: ''
+  default_sender_name: ''
+  default_subject: 'Webform submission from: [webform_submission:source-entity]'
+  default_body_text: "Submitted on [webform_submission:created]\nSubmitted by: [webform_submission:user]\n\nSubmitted values are:\n[webform_submission:values]\n"
+  default_body_html: "<p>Submitted on [webform_submission:created]</p>\n<p>Submitted by: [webform_submission:user]</p>\n<p>Submitted values are:</p>\n[webform_submission:values]\n"
+  roles: {  }
+test:
+  types: "checkbox:\n  - true\ncolor:\n  - '#ffffcc'\n  - '#ffffcc'\n  - '#ccffff'\nemail:\n  - 'example@example.com'\n  - 'test@test.com'\n  - 'random@random.com'\nlanguage_select:\n  - en\nmachine_name:\n  - 'loremipsum'\n  - 'oratione'\n  - 'dixisset'\ntel:\n  - '123-456-7890'\n  - '098-765-4321'\ntextarea:\n  - 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.'\n  - 'Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;'\n  - 'Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.'\ntext_format:\n  - value: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.</p>'\n  - value: '<p>Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;</p>'\n  - value: '<p>Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.</p>'\nurl:\n  - 'http://example.com'\n  - 'http://test.com'\nwebform_email_confirm:\n  - 'example@example.com'\n  - 'test@test.com'\n  - 'random@random.com'\nwebform_email_multiple:\n  - 'example@example.com, test@test.com, random@random.com'\nwebform_location:\n  - value: 'The White House, 1600 Pennsylvania Ave NW, Washington, DC 20500, USA'\n  - value: 'London SW1A 1AA, United Kingdom'\n  - value: 'Moscow, Russia, 10307'\nwebform_time:\n  - '09:00'\n  - '17:00'\n"
+  names: "first_name:\n  - 'John'\n  - 'Paul'\n  - 'Ringo'\n  - 'George'\nlast_name:\n  - 'Lennon'\n  - 'McCartney'\n  - 'Starr'\n  - 'Harrison'\naddress:\n  - '10 Main Street'\n  - '11 Brook Alley Road. APT 1'\nzip:\n  - '11111'\n  - '12345'\n  - '12345-6789'\npostal_code:\n  - '11111'\n  - '12345'\n  - '12345-6789'\nphone:\n  - '123-456-7890'\n  - '098-765-4321'\nfax:\n  - '123-456-7890'\n  - '098-765-4321'\ncity:\n  - 'Springfield'\n  - 'Pleasantville'\n  - 'Hill Valley'\nurl:\n  - 'http://example.com'\n  - 'http://test.com'\ndefault:\n  - 'Loremipsum'\n  - 'Oratione'\n  - 'Dixisset'\n"
+ui:
+  video_display: dialog
+  details_save: true
+  dialog_disabled: false
+  offcanvas_disabled: false
+  contribute_disabled: false
+  promotions_disabled: false
+  description_help: true
+libraries:
+  excluded_libraries:
+    - jquery.chosen
+    - jquery.icheck
+requirements:
+  cdn: true
+  bootstrap: true
+  spam: true
+contribute:
+  account_type: user
+  account_id: null
+langcode: en
+third_party_settings: {  }

--- a/tide_webform.info.yml
+++ b/tide_webform.info.yml
@@ -17,3 +17,4 @@ config_devel:
   optional:
     - block.block.tide_webform_content_rating
     - jsonapi_extras.jsonapi_resource_config.webform--webform
+    - webform.settings

--- a/tide_webform.install
+++ b/tide_webform.install
@@ -139,6 +139,7 @@ function tide_webform_update_8005() {
       'webform_contact',
       'webform_custom_composite',
       'webform_document_file',
+      'webform_element',
       'webform_email_confirm',
       'webform_email_multiple',
       'webform_entity_checkboxes',

--- a/tide_webform.install
+++ b/tide_webform.install
@@ -105,3 +105,80 @@ function tide_webform_update_8004() {
   $webform->setElementProperties('comments', $comments);
   $webform->save();
 }
+
+/**
+ * Updating webform settings to hide unsupported elements.
+ */
+function tide_webform_update_8005() {
+  if (\Drupal::moduleHandler()->moduleExists('webform')) {
+    $webform_elements = [
+      'checkboxes',
+      'color',
+      'container',
+      'datelist',
+      'datetime',
+      'details',
+      'entity_autocomplete',
+      'fieldset',
+      'item',
+      'language_select',
+      'managed_file',
+      'range',
+      'search',
+      'tableselect',
+      'text_format',
+      'value',
+      'view',
+      'webform_address',
+      'webform_audio_file',
+      'webform_autocomplete',
+      'webform_checkboxes_other',
+      'webform_codemirror',
+      'webform_computed_token',
+      'webform_computed_twig',
+      'webform_contact',
+      'webform_custom_composite',
+      'webform_document_file',
+      'webform_email_confirm',
+      'webform_email_multiple',
+      'webform_entity_checkboxes',
+      'webform_entity_radios',
+      'webform_entity_select',
+      'webform_flexbox',
+      'webform_image_file',
+      'webform_likert',
+      'webform_link',
+      'webform_location_places',
+      'webform_mapping',
+      'webform_message',
+      'webform_more',
+      'webform_name',
+      'webform_radios_other',
+      'webform_rating',
+      'webform_same',
+      'webform_scale',
+      'webform_section',
+      'webform_select_other',
+      'webform_signature',
+      'webform_table',
+      'webform_table_row',
+      'webform_table_sort',
+      'webform_tableselect_sort',
+      'webform_telephone',
+      'webform_term_checkboxes',
+      'webform_terms_of_service',
+      'webform_time',
+      'webform_variant',
+      'webform_video_file',
+      'webform_wizard_page',
+    ];
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('webform.settings');
+    $excluded_elements_value = $config->get('element.excluded_elements');
+    foreach ($webform_elements as $webform_element) {
+      $excluded_elements_value[$webform_element] = $webform_element;
+    }
+    $config->set('element.excluded_elements', $excluded_elements_value);
+    $config->save();
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-3943

### Issue
When a user adds a new webform, lots of other form elements are shown which is not supported by FE.

### Changes
1. Added an update hook to exclude fields from CMS that are not supported by FE.
2. Added webform settings as config optional.

Please see the document that lists all the supported form elements at FE - https://digital-engagement.atlassian.net/wiki/spaces/SDP/pages/539099137/Ripple+forms+-+Drupal+webform+elements+supported+not+supported+by+Ripple

Related PR - https://github.com/dpc-sdp/content-vic-gov-au/pull/863