### PR TITLE
[DDS-901] Updated composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,86 +40,6 @@
                 }
             }
         },
-        "ckeditor.autogrow": {
-            "_webform": true,
-            "type": "package",
-            "package": {
-                "name": "ckeditor/autogrow",
-                "version": "4.16.1",
-                "type": "drupal-library",
-                "dist": {
-                    "url": "https://download.ckeditor.com/autogrow/releases/autogrow_4.16.1.zip",
-                    "type": "zip"
-                },
-                "require": {
-                    "composer/installers": "~1.0"
-                }
-            }
-        },
-        "ckeditor.codemirror": {
-            "_webform": true,
-            "type": "package",
-            "package": {
-                "name": "ckeditor/codemirror",
-                "version": "v1.17.12",
-                "type": "drupal-library",
-                "dist": {
-                    "url": "https://github.com/w8tcha/CKEditor-CodeMirror-Plugin/releases/download/v1.17.12/CKEditor-CodeMirror-Plugin.zip",
-                    "type": "zip"
-                },
-                "require": {
-                    "composer/installers": "~1.0"
-                }
-            }
-        },
-        "ckeditor.fakeobjects": {
-            "_webform": true,
-            "type": "package",
-            "package": {
-                "name": "ckeditor/fakeobjects",
-                "version": "4.16.1",
-                "type": "drupal-library",
-                "dist": {
-                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.16.1.zip",
-                    "type": "zip"
-                },
-                "require": {
-                    "composer/installers": "~1.0"
-                }
-            }
-        },
-        "ckeditor.image": {
-            "_webform": true,
-            "type": "package",
-            "package": {
-                "name": "ckeditor/image",
-                "version": "4.16.1",
-                "type": "drupal-library",
-                "dist": {
-                    "url": "https://download.ckeditor.com/image/releases/image_4.16.1.zip",
-                    "type": "zip"
-                },
-                "require": {
-                    "composer/installers": "~1.0"
-                }
-            }
-        },
-        "ckeditor.link": {
-            "_webform": true,
-            "type": "package",
-            "package": {
-                "name": "ckeditor/link",
-                "version": "4.16.1",
-                "type": "drupal-library",
-                "dist": {
-                    "url": "https://download.ckeditor.com/link/releases/link_4.16.1.zip",
-                    "type": "zip"
-                },
-                "require": {
-                    "composer/installers": "~1.0"
-                }
-            }
-        },
         "codemirror": {
             "_webform": true,
             "type": "package",
@@ -170,44 +90,6 @@
                 },
                 "dist": {
                     "url": "https://github.com/jackocnr/intl-tel-input/archive/v16.1.0.zip",
-                    "type": "zip"
-                },
-                "require": {
-                    "composer/installers": "~1.0"
-                }
-            }
-        },
-        "jquery.textcounter": {
-            "_webform": true,
-            "type": "package",
-            "package": {
-                "name": "jquery/textcounter",
-                "version": "0.9.0",
-                "type": "drupal-library",
-                "extra": {
-                    "installer-name": "jquery.textcounter"
-                },
-                "dist": {
-                    "url": "https://github.com/ractoon/jQuery-Text-Counter/archive/0.9.0.zip",
-                    "type": "zip"
-                },
-                "require": {
-                    "composer/installers": "~1.0"
-                }
-            }
-        },
-        "jquery.timepicker": {
-            "_webform": true,
-            "type": "package",
-            "package": {
-                "name": "jquery/timepicker",
-                "version": "1.13.14",
-                "type": "drupal-library",
-                "extra": {
-                    "installer-name": "jquery.timepicker"
-                },
-                "dist": {
-                    "url": "https://github.com/jonthornton/jquery-timepicker/archive/1.13.14.zip",
                     "type": "zip"
                 },
                 "require": {

--- a/composer.json
+++ b/composer.json
@@ -97,22 +97,6 @@
                 }
             }
         },
-        "package/ckeditor-fakeobjects": {
-            "type": "package",
-            "package": {
-                "name": "ckeditor/fakeobjects",
-                "type": "drupal-library",
-                "version": "4.5.11",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.5.11.zip",
-                    "reference": "master"
-                },
-                "require": {
-                    "composer/installers": "~1.0"
-                }
-            }
-        },
         "progress-tracker": {
             "_webform": true,
             "type": "package",


### PR DESCRIPTION
### Changes
Removed the packages that are already defined in tide_core.
As tide_webform already requires tide_core, so the packages that are already in there shouldn't require in the tide_wenform composer.
Related dev-tools PR - https://github.com/dpc-sdp/dev-tools/pull/56