### PR TITLE
[SDPSUP-3768] Add webform patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,13 @@
         "jquery/intl-tel-input": "16.1.0",
         "progress-tracker/progress-tracker": "1.4.0"
     },
+    "extra": {
+        "patches": {
+            "drupal/webform": {
+                "CKEditor Codemirror is still loaded from the CDN even if the library exists in /libraries": "https://www.drupal.org/files/issues/2021-12-20/webform_libraries_3254856.patch"
+            }
+        }
+    },
     "suggest": {
         "dpc-sdp/tide_api:^3.0.0": "Allows to use Drupal in headless mode"
     },


### PR DESCRIPTION
JIRA issue: https://digital-engagement.atlassian.net/jira/servicedesk/projects/SDPSUP/queues/custom/52/SDPSUP-3768

Changed:

1) Locally downloaded webform libraries are not detected properly by the `webform` module, and it continues to load them via CDN, which is not allowed by our security policy. This has been fixed on the dev branch of `webform` - https://www.drupal.org/project/webform/issues/3254856 so I've spun a patch for our version.