### PR TITLE
Removed patch that is removed in recent webform release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,6 @@
     },
     "extra": {
         "patches": {
-            "drupal/webform": {
-                "CKEditor Codemirror is still loaded from the CDN even if the library exists in /libraries": "https://www.drupal.org/files/issues/2021-12-20/webform_libraries_3254856.patch"
-            }
         }
     },
     "suggest": {


### PR DESCRIPTION
### Issue
The patch is already merged in the new release of webform. So as the webform module is not locked, it gets the latest version during build and during composer update, which causes issue on build.

### Changes
Patch is removed.

### Patch link
https://www.drupal.org/project/webform/issues/3254856

### Release note of webform
https://www.drupal.org/project/webform/releases/6.1.3