### PR TITLE
[SDPA-6097] drupal form submission flag downloaded items

### DIFF
--- a/config/optional/system.action.webform_submission_make_process_action.yml
+++ b/config/optional/system.action.webform_submission_make_process_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - tide_webform
+id: webform_submission_process_action
+label: 'Process submission'
+type: webform_submission
+plugin: webform_submission_process_action
+configuration: {  }

--- a/config/optional/system.action.webform_submission_make_process_action.yml
+++ b/config/optional/system.action.webform_submission_make_process_action.yml
@@ -6,5 +6,5 @@ dependencies:
 id: webform_submission_make_process_action
 label: 'Process submission'
 type: webform_submission
-plugin: webform_submission_process_action
+plugin: webform_submission_make_process_action
 configuration: {  }

--- a/config/optional/system.action.webform_submission_make_process_action.yml
+++ b/config/optional/system.action.webform_submission_make_process_action.yml
@@ -3,7 +3,7 @@ status: true
 dependencies:
   module:
     - tide_webform
-id: webform_submission_process_action
+id: webform_submission_make_process_action
 label: 'Process submission'
 type: webform_submission
 plugin: webform_submission_process_action

--- a/config/optional/system.action.webform_submission_make_unprocess_action.yml
+++ b/config/optional/system.action.webform_submission_make_unprocess_action.yml
@@ -6,5 +6,5 @@ dependencies:
 id: webform_submission_make_unprocess_action
 label: 'Unprocess submission'
 type: webform_submission
-plugin: webform_submission_unprocess_action
+plugin: webform_submission_make_unprocess_action
 configuration: {  }

--- a/config/optional/system.action.webform_submission_make_unprocess_action.yml
+++ b/config/optional/system.action.webform_submission_make_unprocess_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - tide_webform
+id: webform_submission_unprocess_action
+label: 'Unprocess submission'
+type: webform_submission
+plugin: webform_submission_unprocess_action
+configuration: {  }

--- a/config/optional/system.action.webform_submission_make_unprocess_action.yml
+++ b/config/optional/system.action.webform_submission_make_unprocess_action.yml
@@ -3,7 +3,7 @@ status: true
 dependencies:
   module:
     - tide_webform
-id: webform_submission_unprocess_action
+id: webform_submission_make_unprocess_action
 label: 'Unprocess submission'
 type: webform_submission
 plugin: webform_submission_unprocess_action

--- a/config/optional/webform.settings.yml
+++ b/config/optional/webform.settings.yml
@@ -38,6 +38,15 @@ settings:
   default_submission_exception_message: 'Unable to process this submission. Please contact the site administrator.'
   default_submission_locked_message: 'This submission has been locked.'
   default_submission_log: false
+  webform_submission_bulk_form: true
+  webform_submission_bulk_form_actions:
+    - webform_submission_make_sticky_action
+    - webform_submission_make_unsticky_action
+    - webform_submission_make_lock_action
+    - webform_submission_make_unlock_action
+    - webform_submission_delete_action
+    - webform_submission_make_process_action
+    - webform_submission_make_unprocess_action
   default_autofill_message: 'This submission has been autofilled with your previous submission.'
   preview_classes: "messages messages--error\nmessages messages--warning\nmessages messages--status\n"
   confirmation_classes: "messages messages--error\nmessages messages--warning\nmessages messages--status\n"

--- a/src/Plugin/Action/WebformSubmissionProcessedAction.php
+++ b/src/Plugin/Action/WebformSubmissionProcessedAction.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\tide_webform\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Makes a webform submission sticky.
+ *
+ * @Action(
+ *   id = "webform_submission_process_action",
+ *   label = @Translation("Process submission"),
+ *   type = "webform_submission"
+ * )
+ */
+class WebformSubmissionProcessedAction extends ActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    /** @var \Drupal\webform\WebformSubmissionInterface $entity */
+    $entity->set('processed', TRUE)->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\webform\WebformSubmissionInterface $object */
+    $result = $object->sticky->access('edit', $account, TRUE)
+      ->andIf($object->access('update', $account, TRUE));
+
+    return $return_as_object ? $result : $result->isAllowed();
+  }
+
+}

--- a/src/Plugin/Action/WebformSubmissionProcessedAction.php
+++ b/src/Plugin/Action/WebformSubmissionProcessedAction.php
@@ -9,7 +9,7 @@ use Drupal\Core\Session\AccountInterface;
  * Makes a webform submission sticky.
  *
  * @Action(
- *   id = "webform_submission_process_action",
+ *   id = "webform_submission_make_process_action",
  *   label = @Translation("Process submission"),
  *   type = "webform_submission"
  * )

--- a/src/Plugin/Action/WebformSubmissionUnprocessedAction.php
+++ b/src/Plugin/Action/WebformSubmissionUnprocessedAction.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\tide_webform\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Makes a webform submission unsticky.
+ *
+ * @Action(
+ *   id = "webform_submission_unprocess_action",
+ *   label = @Translation("Unprocess submission"),
+ *   type = "webform_submission"
+ * )
+ */
+class WebformSubmissionUnprocessedAction extends ActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    /** @var \Drupal\webform\WebformSubmissionInterface $entity */
+    $entity->set('processed', FALSE)->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\webform\WebformSubmissionInterface $object */
+    $result = $object->sticky->access('edit', $account, TRUE)
+      ->andIf($object->access('update', $account, TRUE));
+
+    return $return_as_object ? $result : $result->isAllowed();
+  }
+
+}

--- a/src/Plugin/Action/WebformSubmissionUnprocessedAction.php
+++ b/src/Plugin/Action/WebformSubmissionUnprocessedAction.php
@@ -9,7 +9,7 @@ use Drupal\Core\Session\AccountInterface;
  * Makes a webform submission unsticky.
  *
  * @Action(
- *   id = "webform_submission_unprocess_action",
+ *   id = "webform_submission_make_unprocess_action",
  *   label = @Translation("Unprocess submission"),
  *   type = "webform_submission"
  * )

--- a/src/TideWebformSubmissionExporter.php
+++ b/src/TideWebformSubmissionExporter.php
@@ -56,9 +56,6 @@ class TideWebformSubmissionExporter extends WebformSubmissionExporter {
     $query = parent::getQuery();
     $export_options = $this->getExportOptions();
 
-    $webform = $this->getWebform();
-    $source_entity = $this->getSourceEntity();
-
     if ($export_options['processed']) {
       $query->condition('processed', 0);
     }

--- a/src/TideWebformSubmissionExporter.php
+++ b/src/TideWebformSubmissionExporter.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\tide_webform;
+
+use Drupal\webform\WebformSubmissionExporter;
+use Drupal\webform\WebformSubmissionExporterInterface;
+use Drupal\Core\Archiver\ArchiverManager;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+use Drupal\webform\Plugin\WebformElementManagerInterface;
+use Drupal\webform\Plugin\WebformExporterManagerInterface;
+
+/**
+ * Webform submission exporter.
+ */
+class TideWebformSubmissionExporter extends WebformSubmissionExporter {
+
+  /**
+   * The inner service.
+   *
+   * @var \Drupal\webform\WebformSubmissionExporterInterface
+   */
+  protected $webformSubmissionExporter;
+
+  /**
+   * TideWebformSubmissionExporter function.
+   *
+   * @param \Drupal\webform\Plugin\WebformSubmissionExporterInterface $webformSubmissionExporter
+   *   Lsdfsdf.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Lsdfsdf.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   Lsdfsdf.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Lsdfsdf.
+   * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $stream_wrapper_manager
+   *   Lsdfsdf.
+   * @param \Drupal\Core\Archiver\ArchiverManager $archiver_manager
+   *   Lsdfsdf.
+   * @param \Drupal\webform\Plugin\WebformElementManagerInterface $element_manager
+   *   Lsdfsdf.
+   * @param \Drupal\webform\Plugin\WebformExporterManagerInterface $exporter_manager
+   *   Lsdfsdf.
+   */
+  public function __construct(WebformSubmissionExporterInterface $webformSubmissionExporter, ConfigFactoryInterface $config_factory, FileSystemInterface $file_system, EntityTypeManagerInterface $entity_type_manager, StreamWrapperManagerInterface $stream_wrapper_manager, ArchiverManager $archiver_manager, WebformElementManagerInterface $element_manager, WebformExporterManagerInterface $exporter_manager) {
+    $this->webformSubmissionExporter = $webformSubmissionExporter;
+    parent::__construct($config_factory, $file_system, $entity_type_manager, $stream_wrapper_manager, $archiver_manager, $element_manager, $exporter_manager);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuery() {
+    parent::getQuery();
+    print "Decorator PROTECT Protected\n";
+  }
+
+}

--- a/src/TideWebformSubmissionExporter.php
+++ b/src/TideWebformSubmissionExporter.php
@@ -28,21 +28,21 @@ class TideWebformSubmissionExporter extends WebformSubmissionExporter {
    * TideWebformSubmissionExporter function.
    *
    * @param \Drupal\webform\Plugin\WebformSubmissionExporterInterface $webformSubmissionExporter
-   *   Lsdfsdf.
+   *   The webform submission exporter interface.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   Lsdfsdf.
+   *   The configuration object factory.
    * @param \Drupal\Core\File\FileSystemInterface $file_system
-   *   Lsdfsdf.
+   *   File system service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   Lsdfsdf.
+   *   The entity type manager.
    * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $stream_wrapper_manager
-   *   Lsdfsdf.
+   *   The stream wrapper manager.
    * @param \Drupal\Core\Archiver\ArchiverManager $archiver_manager
-   *   Lsdfsdf.
+   *   The archiver manager.
    * @param \Drupal\webform\Plugin\WebformElementManagerInterface $element_manager
-   *   Lsdfsdf.
+   *   The webform element manager.
    * @param \Drupal\webform\Plugin\WebformExporterManagerInterface $exporter_manager
-   *   Lsdfsdf.
+   *   The results exporter manager.
    */
   public function __construct(WebformSubmissionExporterInterface $webformSubmissionExporter, ConfigFactoryInterface $config_factory, FileSystemInterface $file_system, EntityTypeManagerInterface $entity_type_manager, StreamWrapperManagerInterface $stream_wrapper_manager, ArchiverManager $archiver_manager, WebformElementManagerInterface $element_manager, WebformExporterManagerInterface $exporter_manager) {
     $this->webformSubmissionExporter = $webformSubmissionExporter;
@@ -53,8 +53,16 @@ class TideWebformSubmissionExporter extends WebformSubmissionExporter {
    * {@inheritdoc}
    */
   public function getQuery() {
-    parent::getQuery();
-    print "Decorator PROTECT Protected\n";
+    $query = parent::getQuery();
+    $export_options = $this->getExportOptions();
+
+    $webform = $this->getWebform();
+    $source_entity = $this->getSourceEntity();
+
+    if ($export_options['processed']) {
+      $query->condition('processed', 0);
+    }
+    return $query;
   }
 
 }

--- a/src/TideWebformSubmissionListBuilder.php
+++ b/src/TideWebformSubmissionListBuilder.php
@@ -36,15 +36,15 @@ class TideWebformSubmissionListBuilder extends WebformSubmissionListBuilder {
   /**
    * {@inheritdoc}
    */
-  protected function buildFilterForm() {
-    $formBuilder = parent::buildFilterForm();
-    $state_options = $formBuilder['filter']['state']['#options'];
-    $state_options[static::STATE_PROCESSED] = $this->t('Processed [@total]', ['@total' => $this->getTotal(NULL, static::STATE_PROCESSED, $this->sourceEntityTypeId)]);
-    $state_options[static::STATE_UNPROCESSED] = $this->t('Unprocessed [@total]', ['@total' => $this->getTotal(NULL, static::STATE_UNPROCESSED, $this->sourceEntityTypeId)]);
+  // protected function buildFilterForm() {
+  //   $formBuilder = parent::buildFilterForm();
+  //   $state_options = $formBuilder['filter']['state']['#options'];
+  //   $state_options[static::STATE_PROCESSED] = $this->t('Processed [@total]', ['@total' => $this->getTotal(NULL, static::STATE_PROCESSED, $this->sourceEntityTypeId)]);
+  //   $state_options[static::STATE_UNPROCESSED] = $this->t('Unprocessed [@total]', ['@total' => $this->getTotal(NULL, static::STATE_UNPROCESSED, $this->sourceEntityTypeId)]);
 
-    $formBuilder['filter']['state']['#options'] = $state_options;
-    return $formBuilder;
-  }
+  //   $formBuilder['filter']['state']['#options'] = $state_options;
+  //   return $formBuilder;
+  // }
 
   /**
    * {@inheritdoc}

--- a/src/TideWebformSubmissionListBuilder.php
+++ b/src/TideWebformSubmissionListBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\tide_webform;
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\webform\WebformSubmissionListBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -36,19 +37,6 @@ class TideWebformSubmissionListBuilder extends WebformSubmissionListBuilder {
   /**
    * {@inheritdoc}
    */
-  // protected function buildFilterForm() {
-  //   $formBuilder = parent::buildFilterForm();
-  //   $state_options = $formBuilder['filter']['state']['#options'];
-  //   $state_options[static::STATE_PROCESSED] = $this->t('Processed [@total]', ['@total' => $this->getTotal(NULL, static::STATE_PROCESSED, $this->sourceEntityTypeId)]);
-  //   $state_options[static::STATE_UNPROCESSED] = $this->t('Unprocessed [@total]', ['@total' => $this->getTotal(NULL, static::STATE_UNPROCESSED, $this->sourceEntityTypeId)]);
-
-  //   $formBuilder['filter']['state']['#options'] = $state_options;
-  //   return $formBuilder;
-  // }
-
-  /**
-   * {@inheritdoc}
-   */
   protected function getQuery($keys = '', $state = '', $source_entity = '') {
     $query = parent::getQuery($keys, $state, $source_entity);
     switch ($state) {
@@ -62,6 +50,21 @@ class TideWebformSubmissionListBuilder extends WebformSubmissionListBuilder {
 
     }
     return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $columns = $this->columns;
+    $columns['processed'] = [
+      'title' => $this->t('processed')
+    ];
+    $columns['processed']['name'] = 'processed';
+    $columns['processed']['format'] = 'value';
+    $this->columns = $columns;
+    $this->header = parent::buildHeader();
+    return $this->header;
   }
 
 }

--- a/src/TideWebformSubmissionListBuilder.php
+++ b/src/TideWebformSubmissionListBuilder.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class TideWebformSubmissionListBuilder extends WebformSubmissionListBuilder {
 
-    /**
+  /**
    * Submission state starred.
    */
   const STATE_PROCESSED = 'processed';
@@ -36,19 +36,18 @@ class TideWebformSubmissionListBuilder extends WebformSubmissionListBuilder {
 
   /**
    * {@inheritdoc}
-  */
-    protected function getQuery($keys = '', $state = '', $source_entity = ''){
-        $query = parent::getQuery($keys,$state,$source_entity);
-        switch ($state) {
-            case static::STATE_PROCESSED:
-              $query->condition('processed', 1);
-              break;
-
-            case static::STATE_UNPROCESSED:
-              $query->condition('processed', 0);
-              break;
-          }
-        return $query;
-    }
+   */
+  protected function getQuery($keys = '', $state = '', $source_entity = '') {
+    $query = parent::getQuery($keys, $state, $source_entity);
+    switch ($state) {
+      case static::STATE_PROCESSED:
+        $query->condition('processed', 1);
+        break;
+      case static::STATE_UNPROCESSED:
+        $query->condition('processed', 0);
+        break;
+      }
+    return $query;
+  }
 
 }

--- a/src/TideWebformSubmissionListBuilder.php
+++ b/src/TideWebformSubmissionListBuilder.php
@@ -30,8 +30,20 @@ class TideWebformSubmissionListBuilder extends WebformSubmissionListBuilder {
     /** @var \Drupal\webform\TideWebformSubmissionListBuilder $instance */
     $instance = parent::createInstance($container, $entity_type);
 
-    $instance->initialize();
     return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildFilterForm() {
+    $formBuilder = parent::buildFilterForm();
+    $state_options = $formBuilder['filter']['state']['#options'];
+    $state_options[static::STATE_PROCESSED] = $this->t('Processed [@total]', ['@total' => $this->getTotal(NULL, static::STATE_PROCESSED, $this->sourceEntityTypeId)]);
+    $state_options[static::STATE_UNPROCESSED] = $this->t('Unprocessed [@total]', ['@total' => $this->getTotal(NULL, static::STATE_UNPROCESSED, $this->sourceEntityTypeId)]);
+
+    $formBuilder['filter']['state']['#options'] = $state_options;
+    return $formBuilder;
   }
 
   /**

--- a/src/TideWebformSubmissionListBuilder.php
+++ b/src/TideWebformSubmissionListBuilder.php
@@ -43,10 +43,12 @@ class TideWebformSubmissionListBuilder extends WebformSubmissionListBuilder {
       case static::STATE_PROCESSED:
         $query->condition('processed', 1);
         break;
+
       case static::STATE_UNPROCESSED:
         $query->condition('processed', 0);
         break;
-      }
+
+    }
     return $query;
   }
 

--- a/src/TideWebformSubmissionListBuilder.php
+++ b/src/TideWebformSubmissionListBuilder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\tide_webform;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\webform\WebformSubmissionListBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a list controller for webform submission entity.
+ *
+ * @ingroup webform
+ */
+class TideWebformSubmissionListBuilder extends WebformSubmissionListBuilder {
+
+    /**
+   * Submission state starred.
+   */
+  const STATE_PROCESSED = 'processed';
+
+  /**
+   * Submission state unstarred.
+   */
+  const STATE_UNPROCESSED = 'unprocessed';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    /** @var \Drupal\webform\TideWebformSubmissionListBuilder $instance */
+    $instance = parent::createInstance($container, $entity_type);
+
+    $instance->initialize();
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+  */
+    protected function getQuery($keys = '', $state = '', $source_entity = ''){
+        $query = parent::getQuery($keys,$state,$source_entity);
+        switch ($state) {
+            case static::STATE_PROCESSED:
+              $query->condition('processed', 1);
+              break;
+
+            case static::STATE_UNPROCESSED:
+              $query->condition('processed', 0);
+              break;
+          }
+        return $query;
+    }
+
+}

--- a/src/TideWebformSubmissionListBuilder.php
+++ b/src/TideWebformSubmissionListBuilder.php
@@ -58,13 +58,55 @@ class TideWebformSubmissionListBuilder extends WebformSubmissionListBuilder {
   public function buildHeader() {
     $columns = $this->columns;
     $columns['processed'] = [
-      'title' => $this->t('processed')
+      'title' => $this->t('Export Status'),
     ];
     $columns['processed']['name'] = 'processed';
     $columns['processed']['format'] = 'value';
-    $this->columns = $columns;
-    $this->header = parent::buildHeader();
-    return $this->header;
+    $newOrder = ['processed' => $columns['processed']] + $columns;
+    $this->columns = $newOrder;
+    return parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRowColumn(array $column, EntityInterface $entity) {
+    /** @var \Drupal\webform\WebformSubmissionInterface $entity */
+
+    $name = $column['name'];
+
+    switch ($name) {
+      case 'processed':
+        return $this->getProcessedValue($entity);
+
+      default:
+        return parent::buildRowColumn($column, $entity);
+
+    }
+  }
+
+  /**
+   * Custom function to get value of processed field.
+   *
+   * @param Drupal\Core\Entity\EntityInterface $entity
+   *   The webform submission entity.
+   */
+  public function getProcessedValue(EntityInterface $entity) {
+    /** @var \Drupal\webform\WebformSubmissionInterface $entity */
+
+    $value = $entity->processed->value;
+
+    switch ($value) {
+      case '0':
+        return 'Unprocessed';
+
+      case '1':
+        return 'Processed';
+
+      default:
+        return 'Unprocessed';
+
+    }
   }
 
 }

--- a/tide_webform.install
+++ b/tide_webform.install
@@ -8,6 +8,7 @@
 use Drupal\webform\Entity\Webform;
 use Drupal\block\Entity\Block;
 use Drupal\tide_webform\TideOperation;
+use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Implements hook_install().
@@ -250,4 +251,19 @@ function tide_webform_update_8009() {
     $config->set('elements', $content_value);
     $config->save();
   }
+}
+
+/**
+ * Add 'processed' field to webforms
+ *
+ * @return void
+ */
+function tide_webform_update_8010() {
+  $storage_definition = BaseFieldDefinition::create('boolean')
+      ->setName('Processed')
+      ->setLabel(t('Processed'))
+      ->setDescription(t('A flag that indicates whether the submission has been downloaded'))
+      ->setDefaultValue(FALSE);
+
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('processed', 'webform_submission', 'webform', $storage_definition);
 }

--- a/tide_webform.install
+++ b/tide_webform.install
@@ -255,7 +255,6 @@ function tide_webform_update_8009() {
 
 /**
  * Add 'processed' field to all webforms.
- *
  */
 function tide_webform_update_8010() {
   $storage_definition = BaseFieldDefinition::create('boolean')
@@ -269,7 +268,6 @@ function tide_webform_update_8010() {
 
 /**
  * Add 'processed/unprocessed' actions to webform submissions actions.
- *
  */
 function tide_webform_update_8011() {
   $configs = [
@@ -289,5 +287,3 @@ function tide_webform_update_8011() {
     }
   }
 }
-
-

--- a/tide_webform.install
+++ b/tide_webform.install
@@ -9,7 +9,6 @@ use Drupal\webform\Entity\Webform;
 use Drupal\block\Entity\Block;
 use Drupal\tide_webform\TideOperation;
 use Drupal\Core\Field\BaseFieldDefinition;
-use Drupal\Core\Database\Database;
 
 /**
  * Implements hook_install().
@@ -257,14 +256,13 @@ function tide_webform_update_8009() {
 /**
  * Add 'processed' field to webforms.
  *
- * @return void
  */
 function tide_webform_update_8010() {
   $storage_definition = BaseFieldDefinition::create('boolean')
-      ->setName('Processed')
-      ->setLabel(t('Processed'))
-      ->setDescription(t('A flag that indicates whether the submission has been downloaded'))
-      ->setDefaultValue(FALSE);
+    ->setName('Processed')
+    ->setLabel(t('Processed'))
+    ->setDescription(t('A flag that indicates whether the submission has been downloaded'))
+    ->setDefaultValue(FALSE);
 
   \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('processed', 'webform_submission', 'webform', $storage_definition);
 }
@@ -272,7 +270,6 @@ function tide_webform_update_8010() {
 /**
  * Add 'processed/unprocessed' actions to webform submissions actions.
  *
- * @return void
  */
 function tide_webform_update_8011() {
   $configs = [
@@ -292,4 +289,5 @@ function tide_webform_update_8011() {
     }
   }
 }
+
 

--- a/tide_webform.install
+++ b/tide_webform.install
@@ -287,3 +287,23 @@ function tide_webform_update_8011() {
     }
   }
 }
+
+/**
+ * Add 'webform_submission_actions' to webform settings.
+ */
+function tide_webform_update_8012() {
+  $config_factory = \Drupal::configFactory();
+  $form_actions = [
+    'webform_submission_make_sticky_action',
+    'webform_submission_make_unsticky_action',
+    'webform_submission_make_lock_action',
+    'webform_submission_make_unlock_action',
+    'webform_submission_delete_action',
+    'webform_submission_make_process_action',
+    'webform_submission_make_unprocess_action',
+  ];
+  $config = $config_factory->getEditable('webform.settings');
+  $config->set('webform_submission_bulk_form', TRUE);
+  $config->set('webform_submission_bulk_form_actions', $form_actions);
+  $config->save();
+}

--- a/tide_webform.install
+++ b/tide_webform.install
@@ -9,6 +9,7 @@ use Drupal\webform\Entity\Webform;
 use Drupal\block\Entity\Block;
 use Drupal\tide_webform\TideOperation;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Database\Database;
 
 /**
  * Implements hook_install().
@@ -254,7 +255,7 @@ function tide_webform_update_8009() {
 }
 
 /**
- * Add 'processed' field to webforms
+ * Add 'processed' field to webforms.
  *
  * @return void
  */
@@ -267,3 +268,28 @@ function tide_webform_update_8010() {
 
   \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('processed', 'webform_submission', 'webform', $storage_definition);
 }
+
+/**
+ * Add 'processed/unprocessed' actions to webform submissions actions.
+ *
+ * @return void
+ */
+function tide_webform_update_8011() {
+  $configs = [
+    'system.action.webform_submission_make_process_action' => 'action',
+    'system.action.webform_submission_make_unprocess_action' => 'action',
+  ];
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_webform') . '/config/optional'];
+
+  foreach ($configs as $config => $type) {
+    $config_read = _tide_read_config($config, $config_location, TRUE);
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $id = substr($config, strrpos($config, '.') + 1);
+    if ($storage->load($id) == NULL) {
+      $config_entity = $storage->createFromStorageRecord($config_read);
+      $config_entity->save();
+    }
+  }
+}
+

--- a/tide_webform.install
+++ b/tide_webform.install
@@ -254,7 +254,7 @@ function tide_webform_update_8009() {
 }
 
 /**
- * Add 'processed' field to webforms.
+ * Add 'processed' field to all webforms.
  *
  */
 function tide_webform_update_8010() {

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -41,12 +41,12 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
     $form['#after_build'][] = 'tide_webform_webform_ui_element_form_after_build';
   }
 
-  if ($form_id == 'webform_submission_filter_form') {
-    $options = $form['filter']['state']['#options'];
-    $options['processed'] = 'Processed [' . \Drupal::entityQuery('webform_submission')->condition('processed', '1')->count()->execute() . ']';
-    $options['unprocessed'] = 'Unprocessed [' . \Drupal::entityQuery('webform_submission')->condition('processed', '0')->count()->execute() . ']';
-    $form['filter']['state']['#options'] = $options;
-  }
+  // if ($form_id == 'webform_submission_filter_form') {
+  //   $options = $form['filter']['state']['#options'];
+  //   $options['processed'] = 'Processed [' . \Drupal::entityQuery('webform_submission')->condition('processed', '1')->count()->execute() . ']';
+  //   $options['unprocessed'] = 'Unprocessed [' . \Drupal::entityQuery('webform_submission')->condition('processed', '0')->count()->execute() . ']';
+  //   $form['filter']['state']['#options'] = $options;
+  // }
 
   if (strstr($form_id, 'webform_submission') && strstr($form_id, 'notes_form')) {
     $webform_submission = \Drupal::routeMatch()->getParameter('webform_submission');

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -43,8 +43,8 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
 
   if ($form_id == 'webform_submission_filter_form') {
     $options = $form['filter']['state']['#options'];
-    $options['processed'] = 'Processed ['.\Drupal::entityQuery('webform_submission')->condition('processed', '1')->count()->execute().']';
-    $options['unprocessed'] = 'Unprocessed ['.\Drupal::entityQuery('webform_submission')->condition('processed', '0')->count()->execute().']';
+    $options['processed'] = 'Processed [' .\Drupal::entityQuery('webform_submission')->condition('processed', '1')->count()->execute(). ']';
+    $options['unprocessed'] = 'Unprocessed [' .\Drupal::entityQuery('webform_submission')->condition('processed', '0')->count()->execute(). ']';
     $form['filter']['state']['#options'] = $options;
   }
 }
@@ -158,28 +158,27 @@ function tide_webform_entity_base_field_info_alter(&$fields, EntityTypeInterface
     }
   }
 }
+
 /**
  * Implements hook_entity_base_field_info().
  *
  * @see \Drupal\webform\Entity\WebformSubmission::baseFieldDefinitions()
  */
 function tide_webform_entity_base_field_info(EntityTypeInterface $entity_type) {
-
-  $fields = array();
-
+  $fields = [];
   if ($entity_type->id() == 'webform_submission') {
     $fields['processed'] = BaseFieldDefinition::create('boolean')
-    ->setName('Processed')
-    ->setLabel(t('Processed'))
-    ->setDescription(t('A flag that indicates whether the submission has been downloaded'))
-    ->setDefaultValue(FALSE)
-    ->setDisplayOptions('form', array(
-      'type' => 'boolean_checkbox',
-      'settings' => array(
-        'display_label' => TRUE,
-      ),
-    ))
-    ->setDisplayConfigurable('form', TRUE);
+      ->setName('Processed')
+      ->setLabel(t('Processed'))
+      ->setDescription(t('A flag that indicates whether the submission has been downloaded'))
+      ->setDefaultValue(FALSE)
+      ->setDisplayOptions('form', [
+        'type' => 'boolean_checkbox',
+        'settings' => [
+          'display_label' => FALSE,
+        ],
+      ])
+      ->setDisplayConfigurable('form', FALSE);
   }
 
   return $fields;

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -41,16 +41,11 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
     $form['#after_build'][] = 'tide_webform_webform_ui_element_form_after_build';
   }
 
-  if ($form_id == 'webform_submission_contact_notes_form') {
-    $webform_submission = \Drupal::entityTypeManager()->getStorage('webform_submission')->load(1);
-    $form['processed'] = [
-      '#type' => 'checkbox',
-      '#title' => t('Is this submission downloaded'),
-      '#description' => t('If checked, this submission will be flagged as downloaded'),
-      /*'#default_value' => $webform_submission->get('processed')->value,*/
-      '#return_value' => TRUE,
-    ];
-    $form['actions']['submit']['#submit'][] = 'tide_webform_form_notes_submit';
+  if ($form_id == 'webform_submission_filter_form') {
+    $options = $form['filter']['state']['#options'];
+    $options['processed'] = 'Processed ['.\Drupal::entityQuery('webform_submission')->condition('processed', '1')->count()->execute().']';
+    $options['unprocessed'] = 'Unprocessed ['.\Drupal::entityQuery('webform_submission')->condition('processed', '0')->count()->execute().']';
+    $form['filter']['state']['#options'] = $options;
   }
 }
 
@@ -267,18 +262,9 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
 }
 
 /**
- * Submit callback.
- *
- * @param array $form
- *   The form.
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- *   Form state.
+ * Implements hook_entity_type_alter().
  */
-function tide_webform_form_notes_submit(array $form, FormStateInterface $form_state) {
-  $webform_submission = \Drupal::entityTypeManager()->getStorage('webform_submission')->load(1);
-  $processed = $form_state->getValue('processed');
-
-  /*$webform_submission->set('processed')->$processed;*/
-
-  //Get value of "submitted checkbox' and save as code - find save function for star/flag status.
+function tide_webform_entity_type_alter(array &$entity_types) {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
+  $entity_types['webform_submission']->setListBuilderClass('Drupal\tide_webform\TideWebformSubmissionListBuilder');
 }

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -42,11 +42,12 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
   }
 
   if ($form_id == 'webform_submission_contact_notes_form') {
+    $webform_submission = \Drupal::entityTypeManager()->getStorage('webform_submission')->load(1);
     $form['processed'] = [
       '#type' => 'checkbox',
       '#title' => t('Is this submission downloaded'),
-      '#description' => t('If checked, this submission will be flagged as sownloaded'),
-      /*'#default_value' => $webform_submission->isProcessed(),*/
+      '#description' => t('If checked, this submission will be flagged as downloaded'),
+      /*'#default_value' => $webform_submission->get('processed')->value,*/
       '#return_value' => TRUE,
     ];
     $form['actions']['submit']['#submit'][] = 'tide_webform_form_notes_submit';
@@ -162,6 +163,32 @@ function tide_webform_entity_base_field_info_alter(&$fields, EntityTypeInterface
     }
   }
 }
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * @see \Drupal\webform\Entity\WebformSubmission::baseFieldDefinitions()
+ */
+function tide_webform_entity_base_field_info(EntityTypeInterface $entity_type) {
+
+  $fields = array();
+
+  if ($entity_type->id() == 'webform_submission') {
+    $fields['processed'] = BaseFieldDefinition::create('boolean')
+    ->setName('Processed')
+    ->setLabel(t('Processed'))
+    ->setDescription(t('A flag that indicates whether the submission has been downloaded'))
+    ->setDefaultValue(FALSE)
+    ->setDisplayOptions('form', array(
+      'type' => 'boolean_checkbox',
+      'settings' => array(
+        'display_label' => TRUE,
+      ),
+    ))
+    ->setDisplayConfigurable('form', TRUE);
+  }
+
+  return $fields;
+}
 
 /**
  * Implements hook_ENTITY_TYPE_create_access().
@@ -248,7 +275,10 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
  *   Form state.
  */
 function tide_webform_form_notes_submit(array $form, FormStateInterface $form_state) {
-  print_r('im awesome');
-  exit();
+  $webform_submission = \Drupal::entityTypeManager()->getStorage('webform_submission')->load(1);
+  $processed = $form_state->getValue('processed');
+
+  /*$webform_submission->set('processed')->$processed;*/
+
   //Get value of "submitted checkbox' and save as code - find save function for star/flag status.
 }

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -50,7 +50,7 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
 
   if (strstr($form_id, 'webform_submission') && strstr($form_id, 'notes_form')) {
     $webform_submission = \Drupal::routeMatch()->getParameter('webform_submission');
-     $form['processed'] = [
+    $form['processed'] = [
        '#type' => 'checkbox',
        '#title' => t('Is this submission downloaded'),
        '#description' => t('If checked, this submission will be flagged as downloaded'),
@@ -277,14 +277,18 @@ function tide_webform_entity_type_alter(array &$entity_types) {
 /**
  * Function to get value of processed field.
  *
- * @param WebformSubmission $webform_submission
- * @return $processed[0]['value]
+ * @param Drupal\webform\Entity\WebformSubmission $webform_submission
+ *   Webform submission.
+ *
+ * @return processed[0]['value']
+ *   Returns value of processed field from Webform Submission.
  */
 function tide_webform_get_processed(WebformSubmission $webform_submission){
   $processed = $webform_submission->processed->getValue();
-  if ($processed == null) {
+  if ($processed == NULL) {
     return 0;
   } else {
     return $processed[0]['value'];
   }
 }
+

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -283,7 +283,7 @@ function tide_webform_entity_type_alter(array &$entity_types) {
  * @return processed[0][value]
  *   Returns value of processed field from Webform Submission.
  */
-function tide_webform_get_processed (WebformSubmission $webform_submission){
+function tide_webform_get_processed(WebformSubmission $webform_submission) {
   $processed = $webform_submission->processed->getValue();
   if ($processed == NULL) {
     return 0;

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -10,7 +10,6 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Url;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\WebformSubmissionForm;

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -43,10 +43,22 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
 
   if ($form_id == 'webform_submission_filter_form') {
     $options = $form['filter']['state']['#options'];
-    $options['processed'] = 'Processed [' .\Drupal::entityQuery('webform_submission')->condition('processed', '1')->count()->execute(). ']';
-    $options['unprocessed'] = 'Unprocessed [' .\Drupal::entityQuery('webform_submission')->condition('processed', '0')->count()->execute(). ']';
+    $options['processed'] = 'Processed [' . \Drupal::entityQuery('webform_submission')->condition('processed', '1')->count()->execute() . ']';
+    $options['unprocessed'] = 'Unprocessed [' . \Drupal::entityQuery('webform_submission')->condition('processed', '0')->count()->execute() . ']';
     $form['filter']['state']['#options'] = $options;
   }
+
+  if (strstr($form_id, 'webform_submission') && strstr($form_id, 'notes_form')) {
+    $webform_submission = \Drupal::routeMatch()->getParameter('webform_submission');
+     $form['processed'] = [
+       '#type' => 'checkbox',
+       '#title' => t('Is this submission downloaded'),
+       '#description' => t('If checked, this submission will be flagged as downloaded'),
+       '#default_value' => tide_webform_get_processed($webform_submission),
+       '#return_value' => TRUE,
+     ];
+  }
+
 }
 
 /**
@@ -172,12 +184,6 @@ function tide_webform_entity_base_field_info(EntityTypeInterface $entity_type) {
       ->setLabel(t('Processed'))
       ->setDescription(t('A flag that indicates whether the submission has been downloaded'))
       ->setDefaultValue(FALSE)
-      ->setDisplayOptions('form', [
-        'type' => 'boolean_checkbox',
-        'settings' => [
-          'display_label' => FALSE,
-        ],
-      ])
       ->setDisplayConfigurable('form', FALSE);
   }
 
@@ -266,4 +272,19 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
 function tide_webform_entity_type_alter(array &$entity_types) {
   /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
   $entity_types['webform_submission']->setListBuilderClass('Drupal\tide_webform\TideWebformSubmissionListBuilder');
+}
+
+/**
+ * Function to get value of processed field.
+ *
+ * @param WebformSubmission $webform_submission
+ * @return $processed[0]['value]
+ */
+function tide_webform_get_processed(WebformSubmission $webform_submission){
+  $processed = $webform_submission->processed->getValue();
+  if ($processed == null) {
+    return 0;
+  } else {
+    return $processed[0]['value'];
+  }
 }

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -51,12 +51,12 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
   if (strstr($form_id, 'webform_submission') && strstr($form_id, 'notes_form')) {
     $webform_submission = \Drupal::routeMatch()->getParameter('webform_submission');
     $form['processed'] = [
-       '#type' => 'checkbox',
-       '#title' => t('Is this submission downloaded'),
-       '#description' => t('If checked, this submission will be flagged as downloaded'),
-       '#default_value' => tide_webform_get_processed($webform_submission),
-       '#return_value' => TRUE,
-     ];
+      '#type' => 'checkbox',
+      '#title' => t('Is this submission downloaded'),
+      '#description' => t('If checked, this submission will be flagged as downloaded'),
+      '#default_value' => tide_webform_get_processed($webform_submission),
+      '#return_value' => TRUE,
+    ];
   }
 
 }
@@ -280,15 +280,15 @@ function tide_webform_entity_type_alter(array &$entity_types) {
  * @param Drupal\webform\Entity\WebformSubmission $webform_submission
  *   Webform submission.
  *
- * @return processed[0]['value']
+ * @return processed[0][value]
  *   Returns value of processed field from Webform Submission.
  */
-function tide_webform_get_processed(WebformSubmission $webform_submission){
+function tide_webform_get_processed (WebformSubmission $webform_submission){
   $processed = $webform_submission->processed->getValue();
   if ($processed == NULL) {
     return 0;
-  } else {
+  }
+  else {
     return $processed[0]['value'];
   }
 }
-

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\WebformSubmissionForm;
@@ -57,6 +58,22 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
       '#default_value' => tide_webform_get_processed($webform_submission),
       '#return_value' => TRUE,
     ];
+  }
+
+  if ($form_id == 'webform_results_export') {
+    $form['export']['download']['processed'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Only download unprocessed submissions'),
+      '#default_value' => TRUE,
+    ];
+    $form['export']['download']['process_submissions'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Downloaded submissions are marked as processed'),
+      '#default_value' => TRUE,
+    ];
+
+    $form['#submit'][] = 'tide_webform_form_webform_results_export_form_submit';
+
   }
 
 }
@@ -310,4 +327,23 @@ function tide_webform_submission_filter_query($value) {
   $query->count();
   $total = $query->execute();
   return $total;
+}
+
+/**
+ * Submit callback.
+ *
+ * @param array $form
+ *   The form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ */
+function tide_webform_form_webform_results_export_form_submit(array $form, FormStateInterface $form_state) {
+  $processed = $form_state->getValue('processed');
+  $route = $form_state->getRedirect();
+  $route_parameters = $route->getRouteParameters();
+  $options = $route->getOptions();
+  $query = $options['query'];
+  $query['processed'] = $processed;
+  $options = ['query' => $query];
+  $form_state->setRedirect('entity.webform.results_export', $route_parameters, $options);
 }

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -61,9 +61,14 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
   }
 
   if ($form_id == 'webform_results_export') {
-    $form['export']['download']['processed'] = [
+    $form['export']['download']['unprocessed_submissions'] = [
       '#type' => 'checkbox',
       '#title' => t('Only download unprocessed submissions'),
+      '#default_value' => TRUE,
+    ];
+    $form['export']['download']['process_submissions'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Download submissions are marked as processed'),
       '#default_value' => TRUE,
     ];
 
@@ -333,12 +338,14 @@ function tide_webform_submission_filter_query($value) {
  *   Form state.
  */
 function tide_webform_form_webform_results_export_form_submit(array $form, FormStateInterface $form_state) {
-  $processed = $form_state->getValue('processed');
+  $unprocessed_submissions = $form_state->getValue('unprocessed_submissions');
+  $process_submissions = $form_state->getValue('process_submissions');
   $route = $form_state->getRedirect();
   $route_parameters = $route->getRouteParameters();
   $options = $route->getOptions();
   $query = $options['query'];
-  $query['processed'] = $processed;
+  $query['unprocessed_submissions'] = $unprocessed_submissions;
+  $query['process_submissions'] = $process_submissions;
   $options = ['query' => $query];
   $form_state->setRedirect('entity.webform.results_export', $route_parameters, $options);
 }

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -41,12 +41,12 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
     $form['#after_build'][] = 'tide_webform_webform_ui_element_form_after_build';
   }
 
-  // if ($form_id == 'webform_submission_filter_form') {
-  //   $options = $form['filter']['state']['#options'];
-  //   $options['processed'] = 'Processed [' . \Drupal::entityQuery('webform_submission')->condition('processed', '1')->count()->execute() . ']';
-  //   $options['unprocessed'] = 'Unprocessed [' . \Drupal::entityQuery('webform_submission')->condition('processed', '0')->count()->execute() . ']';
-  //   $form['filter']['state']['#options'] = $options;
-  // }
+  if ($form_id == 'webform_submission_filter_form') {
+    $options = $form['filter']['state']['#options'];
+    $options['processed'] = 'Processed [' . tide_webform_submission_filter_query(1) . ']';
+    $options['unprocessed'] = 'Unprocessed [' . tide_webform_submission_filter_query(0) . ']';
+    $form['filter']['state']['#options'] = $options;
+  }
 
   if (strstr($form_id, 'webform_submission') && strstr($form_id, 'notes_form')) {
     $webform_submission = \Drupal::routeMatch()->getParameter('webform_submission');
@@ -291,4 +291,23 @@ function tide_webform_get_processed(WebformSubmission $webform_submission) {
   else {
     return $processed[0]['value'];
   }
+}
+
+/**
+ * Function to build query for filter on webform submissions pages.
+ *
+ * @return total
+ *   Returns total from the webform submission count.
+ */
+function tide_webform_submission_filter_query($value) {
+  $query = \Drupal::entityQuery('webform_submission');
+  $query->condition('processed', $value);
+  $webform_submission = \Drupal::routeMatch()->getParameter('webform');
+  if ($webform_submission != NULL) {
+    $id = $webform_submission->id();
+    $query->condition('webform_id', $id);
+  }
+  $query->count();
+  $total = $query->execute();
+  return $total;
 }

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -40,6 +40,17 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
   if ($form_id == 'webform_ui_element_form') {
     $form['#after_build'][] = 'tide_webform_webform_ui_element_form_after_build';
   }
+
+  if ($form_id == 'webform_submission_contact_notes_form') {
+    $form['processed'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Is this submission downloaded'),
+      '#description' => t('If checked, this submission will be flagged as sownloaded'),
+      /*'#default_value' => $webform_submission->isProcessed(),*/
+      '#return_value' => TRUE,
+    ];
+    $form['actions']['submit']['#submit'][] = 'tide_webform_form_notes_submit';
+  }
 }
 
 /**
@@ -226,4 +237,18 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
       }
     }
   }
+}
+
+/**
+ * Submit callback.
+ *
+ * @param array $form
+ *   The form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ */
+function tide_webform_form_notes_submit(array $form, FormStateInterface $form_state) {
+  print_r('im awesome');
+  exit();
+  //Get value of "submitted checkbox' and save as code - find save function for star/flag status.
 }

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -66,11 +66,6 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
       '#title' => t('Only download unprocessed submissions'),
       '#default_value' => TRUE,
     ];
-    $form['export']['download']['process_submissions'] = [
-      '#type' => 'checkbox',
-      '#title' => t('Downloaded submissions are marked as processed'),
-      '#default_value' => TRUE,
-    ];
 
     $form['#submit'][] = 'tide_webform_form_webform_results_export_form_submit';
 

--- a/tide_webform.services.yml
+++ b/tide_webform.services.yml
@@ -4,4 +4,4 @@ services:
     public: false
     decorates: webform_submission.exporter
     decoration_priority: 4
-    arguments: ['@tide_webform.exporter.inner']
+    arguments: ['@tide_webform.exporter.inner', '@config.factory', '@file_system', '@entity_type.manager', '@stream_wrapper_manager', '@plugin.manager.archiver', '@plugin.manager.webform.element', '@plugin.manager.webform.exporter']

--- a/tide_webform.services.yml
+++ b/tide_webform.services.yml
@@ -1,0 +1,7 @@
+services:
+  tide_webform.exporter:
+    class: Drupal\tide_webform\TideWebformSubmissionExporter
+    public: false
+    decorates: webform_submission.exporter
+    decoration_priority: 4
+    arguments: ['@tide_webform.exporter.inner']


### PR DESCRIPTION
**JIRA issue:** https://digital-vic.atlassian.net/browse/SDPAP-6097?atlOrigin=eyJpIjoiMjgyZGRlN2M5ZDg0NGU4N2IyYjdiOWU2OTU4YmE4NDkiLCJwIjoiaiJ9
https://digital-vic.atlassian.net/browse/SDPAP-6099?atlOrigin=eyJpIjoiYmRhMjI3MjU3NzFkNDk5MWI5MTYxMTkwNjVlNzg3NzkiLCJwIjoiaiJ9

**Test Environment
https://nginx-php.pr-106.content-reference-sdp-vic-gov-au.sdp2.sdp.vic.gov.au/

### Changed

1.  Added new "Processed" boolean field for all webform submission (hidden when creating a webform submission)
2. Added 2 new filters for Webform Submissions results table for "Processed" and "Unprocessed" so users can filter the submission table for these values.
3. Added 2 new Bulk Operations Actions for Webform Submissions results table to Bulk Process Submissions or Bulk Unprocess submissions.
4. On the Webform Submission Notes tab an editable boolean field for "Is this submission downloaded?" has been added
5. On the downloads form - 2 checkbox options have been added, "Only download unprocessed submissions" and "Downloaded submissions are marked as processed"
6. Added a new column to the Webform submissions table that shows Export Status of either "Processed" or "Unprocessed"
7. Added a task to the download to log the event in both Drupal logging and the Admin Audit Trail with "datetime, user, number of submissions processed".

### Screenshots
2. 
![Screen Shot 2022-07-15 at 2 48 01 pm](https://user-images.githubusercontent.com/105895266/179153851-9bd04ad1-fb5d-4540-af76-064d2ee7d2b8.png)

3.
![Screen Shot 2022-07-15 at 2 48 11 pm](https://user-images.githubusercontent.com/105895266/179153895-66bcaa7b-4923-4b48-a8ff-f559e1f37a50.png)

4. 
![Screen Shot 2022-07-15 at 2 47 41 pm](https://user-images.githubusercontent.com/105895266/179153976-848ec4fe-5e1a-43b1-b433-ebfd65ba7a86.png)

5.
![Screen Shot 2022-07-15 at 2 48 25 pm](https://user-images.githubusercontent.com/105895266/179154008-708832ab-c80f-44c5-9b74-908e4e15cd7a.png)

6. 
![Screen Shot 2022-07-15 at 2 58 01 pm](https://user-images.githubusercontent.com/105895266/179154031-9e4b126f-8c25-4f35-a2b0-6d6d0d3ac465.png)

7.

![Screen Shot 2022-07-15 at 2 55 49 pm](https://user-images.githubusercontent.com/105895266/179154080-84c8a5a2-911d-410c-964c-fa5a338b3862.png)
![Screen Shot 2022-07-15 at 2 56 04 pm](https://user-images.githubusercontent.com/105895266/179154089-926fdabe-e993-4b0c-8f18-35b6c0869671.png)
