### PR TITLE
[SDPAP-5181] Added string convertion for grant form number field.

### DIFF
--- a/tide_webform.module
+++ b/tide_webform.module
@@ -272,6 +272,18 @@ function tide_webform_form_webform_add_form_alter(&$form, FormStateInterface $fo
  */
 function tide_webform_webform_submission_presave(WebformSubmission $webform_submission) {
   $elements = $webform_submission->getWebform()->getElementsDecoded();
+  // SDPAP-5181 Front end submits the value as numeric
+  // Triggers invalid validation error from core 
+  // See /Drupal/Core/Form/FormValidator.php $is_empty_value
+  $submission_data = $webform_submission->getData();
+  foreach ($elements as $key => $element) {
+    if ($element['#type'] == 'number') {
+      if (is_numeric($submission_data[$key])) {
+        $submission_data[$key] = strval($submission_data[$key]);
+        $webform_submission->setData($submission_data);
+      }
+    }
+  }
   $errors = WebformSubmissionForm::validateWebformSubmission($webform_submission);
   if ($errors) {
     foreach ($elements as $key => $element) {

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -272,9 +272,9 @@ function tide_webform_form_webform_add_form_alter(&$form, FormStateInterface $fo
  */
 function tide_webform_webform_submission_presave(WebformSubmission $webform_submission) {
   $elements = $webform_submission->getWebform()->getElementsDecoded();
-  // SDPAP-5181 Front end submits the value as numeric
-  // Triggers invalid validation error from core 
-  // See /Drupal/Core/Form/FormValidator.php $is_empty_value
+  // SDPAP-5181 Front end submits the value as numeric.
+  // Triggers invalid validation error from core.
+  // See /Drupal/Core/Form/FormValidator.php $is_empty_value.
   $submission_data = $webform_submission->getData();
   foreach ($elements as $key => $element) {
     if ($element['#type'] == 'number') {


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-5181

### Issue
In webform presave webform submission hook, we are calling a submission validation function. That gets triggered on every time a form gets submitted using ripple. At the BE, all the form submission values for number fields are in string. But when a number filed gets submitted using ripple, it sends it as a numeric. So when a field is number and it is set as required field, the submission goes to a wrong validation check and triggers a false validation error. See the **_/Drupal/Core/Form/FormValidator.php_ and check _$is_empty_value_ variable.**

Couldn't submit a patch because it is not an issue from drupal, it is an issue from how ripple returns the values. In which case, ripple is also right, number field gets submitted as numeric.

### Changes
In the presave hook, before the error validation, check for any elements which are number and if the field has values, then convert it to string.

### Test links - 
BE link - https://nginx-php.pr-1433.content-vic.sdp4.sdp.vic.gov.au/
connected to FE link - https://app.pr-951.vic-gov-au.sdp4.sdp.vic.gov.au/

**Testing steps -** 
1. Add any drupal form in a content page e.g in a landing page. 

2. Make sure the form has a mandatory number field.

3. Go to the FE and and try to enter 0 to that field and it should submit the form

4. BE should capture those submission results