### PR TITLE
Removes provide section.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,6 @@
         "jquery/intl-tel-input": "16.1.0",
         "progress-tracker/progress-tracker": "1.4.0"
     },
-    "provide": {
-        "drupal/ckeditor": "*"
-    },
     "extra": {
         "patches": {
         }


### PR DESCRIPTION
### Description
Remove provide section that is no longer required for Drupal 9.4 upgrade.

Code was merged to develop for 
PR: https://github.com/dpc-sdp/tide_webform/pull/64
JIRA: https://digital-vic.atlassian.net/browse/SDPAP-6373
