### PR TITLE
[SDPAP-6895] Adds tide_remote_post handler with the hook

### DIFF
--- a/src/Plugin/WebformHandler/TideRemotePostWebformHandler.php
+++ b/src/Plugin/WebformHandler/TideRemotePostWebformHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\tide_webform\Plugin\WebformHandler;
+
+use Drupal\webform\WebformSubmissionInterface;
+use Drupal\webform\Plugin\WebformHandler\RemotePostWebformHandler;
+
+/**
+ * Tide Webform submission remote post handler.
+ *
+ * @WebformHandler(
+ *   id = "tide_remote_post",
+ *   label = @Translation("Tide remote post"),
+ *   category = @Translation("External"),
+ *   description = @Translation("Posts webform submissions to a URL with a chance to modify it."),
+ *   cardinality = \Drupal\webform\Plugin\WebformHandlerInterface::CARDINALITY_UNLIMITED,
+ *   results = \Drupal\webform\Plugin\WebformHandlerInterface::RESULTS_PROCESSED,
+ *   submission = \Drupal\webform\Plugin\WebformHandlerInterface::SUBMISSION_OPTIONAL,
+ *   tokens = TRUE,
+ * )
+ */
+class TideRemotePostWebformHandler extends RemotePostWebformHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getRequestData($state, WebformSubmissionInterface $webform_submission) {
+    $data = parent::getRequestData($state, $webform_submission);
+    \Drupal::moduleHandler()->alter('tide_webform_post', $data, $this);
+    return $data;
+  }
+
+}

--- a/tide_webform.api.php
+++ b/tide_webform.api.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * API.
+ */
+
+/**
+ * Alter data before posting.
+ *
+ * By implementing this hook and enabling `tide_remote_post` as your POST
+ * handler, you can modify the body of POST.
+ * This hook mostly uses for dealing with composite data.
+ *
+ * @param array $data
+ *   Array keyed by webform field name.
+ */
+function hook_tide_webform_post_alter(array &$data, \Drupal\webform\Plugin\WebformHandlerInterface $handler) {
+  if ($handler->getWebform()->id() == 'an_example_tide_form_') {
+    if ($data['a_field_name']) {
+      $data['a_field_name'] = ['hello word'];
+    }
+  }
+
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-6895

### Motivation
ESTA's webform contains nested data, but drupal webform doesn't support it well. 

We could do some composite elements by manually modifying the YAML config,  but it still has some limitations and is unsuitable for our case.

----
Drupal webform  `Date` or `Datelist` element only supports string storage; when the date goes to the POST handler, it is still a string, for example, `2022-07-01`.

ESTA expected data
```json
    "date_of_call": {
        "day": "17",
        "month": "7",
        "year": "1979"
    },
```
