### PR TITLE
[SDPAP-7018][SDPAP-7016] Adds an error handler.

### DIFF
--- a/tide_webform.module
+++ b/tide_webform.module
@@ -273,10 +273,8 @@ function tide_webform_form_webform_add_form_alter(&$form, FormStateInterface $fo
 function tide_webform_webform_submission_presave(WebformSubmission $webform_submission) {
   // Preparing confirmation message.
   $webform = $webform_submission->getWebform();
-  $token = $webform->getElementDecoded('confirmation_message')['#default_value'];
-  if (!empty($token)) {
+  if ($webform->getElement('confirmation_message') !== NULL) {
     $webform_submission->set('notes', $webform_submission->uuid());
-    $webform_submission->setElementData('confirmation_message', $token);
   }
   $elements = $webform_submission->getWebform()->getElementsDecoded();
   // SDPAP-5181 Front end submits the value as numeric.


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-7018
https://digital-vic.atlassian.net/browse/SDPAP-7016

### Motivation
When we integrate with 3rd parties, FE doesn't know if the `POST` gets successful or not. as the backend returns a webform submission response with a `200 code` to the  FE always, which is mainly because the handler runs after the submissions.

### Change
- `tide_remote_post` handler now supports `Custom response messages`.
![CleanShot 2022-12-06 at 11 22 30](https://user-images.githubusercontent.com/8788145/205775462-3b934425-cb17-4b89-9ef4-7d20618acce3.png)
Developers can set up a variety of response messages that will feed the FE `ripple`.
the response message for FE is `{http-response-code}|{message}`
e.g. for ESTA case
   `401|User Not Authenticated`
   `200|<p>Thank you for your request. We have created ticket number ....`
   `401|User Not Authenticated`

![CleanShot 2022-12-06 at 11 28 11](https://user-images.githubusercontent.com/8788145/205776105-dad64cde-89b0-451b-828c-54fc9e3e08b0.png)
confirmed by @MdNadimHossain .

- we provide an option in `JSONAPI extra` setting page to indicate whether the user wants to keep or delete the submission. 
![CleanShot 2022-12-06 at 11 34 30](https://user-images.githubusercontent.com/8788145/205776866-2be3cfa5-ef78-4255-93de-be91248f72fe.png)


