### PR TITLE
[SDPAP-6978] Limit webform textfield counter.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "drupal-module",
   "license": "GPL-2.0-or-later",
   "require": {
-    "dpc-sdp/tide_core": "^3.1.11",
+    "dpc-sdp/tide_core": "dev-reference",
     "drupal/token_conditions": "dev-compatible-with-drupal-9",
     "drupal/webform": "^6.1@beta",
     "choices/choices": "9.0.1",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "drupal-module",
   "license": "GPL-2.0-or-later",
   "require": {
-    "dpc-sdp/tide_core": "dev-reference",
+    "dpc-sdp/tide_core": "^3.1.11",
     "drupal/token_conditions": "dev-compatible-with-drupal-9",
     "drupal/webform": "^6.1@beta",
     "choices/choices": "9.0.1",

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -379,7 +379,6 @@ function tide_webform_form_webform_results_export_form_submit(array $form, FormS
 function tide_webform_webform_element_default_properties_alter(array &$properties, array &$definition) {
   if (($definition["id"] === "textfield") && (empty($properties["counter_type"]))) {
     $properties["counter_type"] = "character";
-    $properties["counter_minimum"] = 0;
     $properties["counter_maximum"] = 255;
   }
 }

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -365,3 +365,20 @@ function tide_webform_form_webform_results_export_form_submit(array $form, FormS
   $options = ['query' => $query];
   $form_state->setRedirect('entity.webform.results_export', $route_parameters, $options);
 }
+
+/**
+ * Alter a webform element's default properties.
+ *
+ * @param array &$properties
+ *   An associative array containing an element's default properties.
+ * @param array $definition
+ *   The webform element's definition.
+ *
+ * @see webform_example_element_properties.module
+ */
+function tide_webform_webform_element_default_properties_alter(array &$properties, array &$definition) {
+  if (($definition["id"] === "textfield") && (empty($properties["counter_type"]))) {
+    $properties["counter_type"] = "character";
+    $properties["counter_maximum"] = 255;
+  }
+}

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -379,6 +379,7 @@ function tide_webform_form_webform_results_export_form_submit(array $form, FormS
 function tide_webform_webform_element_default_properties_alter(array &$properties, array &$definition) {
   if (($definition["id"] === "textfield") && (empty($properties["counter_type"]))) {
     $properties["counter_type"] = "character";
+    $properties["counter_minimum"] = 0;
     $properties["counter_maximum"] = 255;
   }
 }


### PR DESCRIPTION
**JIRA:** https://digital-vic.atlassian.net/browse/SDPAP-6987

**Issue:**
Webform text field does not validate character limit until it got into db and threw exception error.

**Solution:**
Add counter maximum to allow validation prior to submission.

**Screenshot:**