### PR TITLE
[SDPAP-7618] Add reCAPTCHA to the third part settings for all webforms

### DIFF
--- a/tests/behat/features/webform_recaptcha.feature
+++ b/tests/behat/features/webform_recaptcha.feature
@@ -1,0 +1,24 @@
+@tide
+Feature: Webform "reCAPTCHA" exists.
+
+  Ensure that the 'reCAPTCHA' THIRD PARTY SETTINGS exists
+
+  @api @suggest
+  Scenario: The content type has the expected fields (and labels where we can use them).
+    Given I am logged in as a user with the "administrator" role
+    When I visit "admin/structure/webform/manage/tide_webform_content_rating/settings"
+    Then I should see the text "TIDE WEBFORM RECAPTCHA"
+    Then I check the box "Enable reCAPTCHA"
+    And I press "Save"
+    When I send a GET request to "/api/v1/webform/webform?filter[drupal_internal__id][value]=tide_webform_content_rating"
+    Then the response code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.third_party_settings.tide_webform.tide_webform_recaptcha" should be equal to "1"
+    When I visit "admin/structure/webform/manage/tide_webform_content_rating/settings"
+    Then I should see the text "TIDE WEBFORM RECAPTCHA"
+    Then I uncheck the box "Enable reCAPTCHA"
+    And I press "Save"
+    When I send a GET request to "/api/v1/webform/webform?filter[drupal_internal__id][value]=tide_webform_content_rating"
+    Then the response code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.third_party_settings.tide_webform.tide_webform_recaptcha" should be equal to "0"

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -365,3 +365,21 @@ function tide_webform_form_webform_results_export_form_submit(array $form, FormS
   $options = ['query' => $query];
   $form_state->setRedirect('entity.webform.results_export', $route_parameters, $options);
 }
+
+/**
+ * Implements hook_webform_third_party_settings_form_alter().
+ */
+function tide_webform_webform_third_party_settings_form_alter(array &$form, FormStateInterface $form_state) {
+  $webform = $form_state->getFormObject()->getEntity();
+  $third_party_settings = $webform->getThirdPartySettings('tide_webform');
+  $form['third_party_settings']['tide_webform'] = [
+    '#type' => 'details',
+    '#title' => t('Tide webform reCAPTCHA'),
+    '#open' => TRUE,
+  ];
+  $form['third_party_settings']['tide_webform']['tide_webform_recaptcha'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enable reCAPTCHA'),
+    '#default_value' => empty($third_party_settings['tide_webform_recaptcha']) ? NULL : $third_party_settings['tide_webform_recaptcha'],
+  ];
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-7618

### Change
Add reCAPTCHA to the third part settings for all webforms with some tests

### JSONAPI Output 
```
            "attributes": {
                "langcode": "en",
                "status": "open",
                "dependencies": {
                    "module": [
                        "tide_webform"
                    ]
                },
                "third_party_settings": {
                    "tide_webform": {
                        "tide_webform_recaptcha": 1
                    }
                },
```
`tide_webform.tide_webform_recaptcha` could be `0` for unenabled, `1` for enabled or none-exists.