### PR TITLE
[SDPAP-8012] Add default `maxlength` for webforms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "dpc-sdp/tide_core": "^3.2.5",
+    "dpc-sdp/tide_api": "^3.0.0",
     "drupal/token_conditions": "dev-compatible-with-drupal-9",
     "drupal/webform": "^6.2@beta",
     "choices/choices": "9.0.1",

--- a/config/optional/jsonapi_extras.jsonapi_resource_config.webform--webform.yml
+++ b/config/optional/jsonapi_extras.jsonapi_resource_config.webform--webform.yml
@@ -125,7 +125,7 @@ resourceFields:
     fieldName: elements
     publicName: elements
     enhancer:
-      id: yaml
+      id: default_maxlength_enhancer
     disabled: false
     advancedOptionsIcon: ''
     enhancer_label: ''

--- a/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\tide_webform\Plugin\jsonapi\FieldEnhancer;
+
+use Drupal\webform\Plugin\WebformElement\TextBase;
+use Drupal\Core\Serialization\Yaml;
+use Drupal\jsonapi_extras\Plugin\ResourceFieldEnhancerBase;
+use Shaper\Util\Context;
+
+/**
+ * Alters date to add default value to the text based fields.
+ *
+ * @ResourceFieldEnhancer(
+ *   id = "default_maxlength_enhancer",
+ *   label = @Translation("Default Maxlength enhancer"),
+ *   description = @Translation("Default Maxlength enhancer")
+ * )
+ */
+class DefaultMaxlengthEnhancer extends ResourceFieldEnhancerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doUndoTransform($data, Context $context) {
+    if ($cache = \Drupal::cache()->get('webform_text_fields_default_maxlength')) {
+      $result = $cache->data;
+    }
+    else {
+      $types = [];
+      $result = Yaml::decode($data);
+      /** @var Drupal\webform\Plugin\WebformElementManager $plugin_webform */
+      $plugin_webform = \Drupal::service('plugin.manager.webform.element');
+      foreach ($plugin_webform->getInstances() as $id => $instance) {
+        if ($instance instanceof TextBase) {
+          $types[] = $id;
+        }
+      }
+      $this->updateElementsWithDefaultValue($types, $result);
+      \Drupal::cache()->set('webform_text_fields_default_maxlength', Yaml::encode($result));
+    }
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doTransform($data, Context $context) {
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOutputJsonSchema() {
+    return [
+      'anyOf' => [
+        ['type' => 'array'],
+        ['type' => 'boolean'],
+        ['type' => 'null'],
+        ['type' => 'number'],
+        ['type' => 'object'],
+        ['type' => 'string'],
+      ],
+    ];
+  }
+
+  /**
+   * Update elements with the default value.
+   */
+  public function updateElementsWithDefaultValue($types, &$array) {
+    foreach ($array as &$value) {
+      if (is_array($value)) {
+        if (isset($value['#type']) && in_array($value['#type'], $types) && !isset($value['#default_value'])) {
+          $value['#default_value'] = 255;
+        }
+        self::updateElementsWithDefaultValue($types, $value);
+      }
+    }
+  }
+
+}

--- a/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
@@ -21,7 +21,6 @@ class DefaultMaxlengthEnhancer extends YamlEnhancer {
    * {@inheritdoc}
    */
   protected function doUndoTransform($data, Context $context) {
-
     if ($cache = \Drupal::cache()->get('webform_text_fields_default_maxlength')) {
       $result = $cache->data;
     }
@@ -39,22 +38,6 @@ class DefaultMaxlengthEnhancer extends YamlEnhancer {
       \Drupal::cache()->set('webform_text_fields_default_maxlength', $result);
     }
     return $result;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getOutputJsonSchema() {
-    return [
-      'anyOf' => [
-        ['type' => 'array'],
-        ['type' => 'boolean'],
-        ['type' => 'null'],
-        ['type' => 'number'],
-        ['type' => 'object'],
-        ['type' => 'string'],
-      ],
-    ];
   }
 
   /**

--- a/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
@@ -21,12 +21,13 @@ class DefaultMaxlengthEnhancer extends YamlEnhancer {
    * {@inheritdoc}
    */
   protected function doUndoTransform($data, Context $context) {
-    $result = parent::doUndoTransform($data, $context);
+
     if ($cache = \Drupal::cache()->get('webform_text_fields_default_maxlength')) {
       $result = $cache->data;
     }
     else {
       $types = [];
+      $result = parent::doUndoTransform($data, $context);
       /** @var Drupal\webform\Plugin\WebformElementManager $plugin_webform */
       $plugin_webform = \Drupal::service('plugin.manager.webform.element');
       foreach ($plugin_webform->getInstances() as $id => $instance) {
@@ -62,8 +63,8 @@ class DefaultMaxlengthEnhancer extends YamlEnhancer {
   public function updateElementsWithDefaultValue($types, &$array) {
     foreach ($array as &$value) {
       if (is_array($value)) {
-        if (isset($value['#type']) && in_array($value['#type'], $types) && !isset($value['#default_value'])) {
-          $value['#default_value'] = 255;
+        if (isset($value['#type']) && in_array($value['#type'], $types) && !isset($value['#maxlength'])) {
+          $value['#maxlength'] = 255;
         }
         self::updateElementsWithDefaultValue($types, $value);
       }

--- a/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tide_webform\Plugin\jsonapi\FieldEnhancer;
 
-use Drupal\webform\Plugin\WebformElement\TextBase;
 use Drupal\tide_api\Plugin\jsonapi\FieldEnhancer\YamlEnhancer;
+use Drupal\webform\Plugin\WebformElement\TextBase;
 use Shaper\Util\Context;
 
 /**

--- a/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/DefaultMaxlengthEnhancer.php
@@ -3,8 +3,7 @@
 namespace Drupal\tide_webform\Plugin\jsonapi\FieldEnhancer;
 
 use Drupal\webform\Plugin\WebformElement\TextBase;
-use Drupal\Core\Serialization\Yaml;
-use Drupal\jsonapi_extras\Plugin\ResourceFieldEnhancerBase;
+use Drupal\tide_api\Plugin\jsonapi\FieldEnhancer\YamlEnhancer;
 use Shaper\Util\Context;
 
 /**
@@ -16,18 +15,18 @@ use Shaper\Util\Context;
  *   description = @Translation("Default Maxlength enhancer")
  * )
  */
-class DefaultMaxlengthEnhancer extends ResourceFieldEnhancerBase {
+class DefaultMaxlengthEnhancer extends YamlEnhancer {
 
   /**
    * {@inheritdoc}
    */
   protected function doUndoTransform($data, Context $context) {
+    $result = parent::doUndoTransform($data, $context);
     if ($cache = \Drupal::cache()->get('webform_text_fields_default_maxlength')) {
       $result = $cache->data;
     }
     else {
       $types = [];
-      $result = Yaml::decode($data);
       /** @var Drupal\webform\Plugin\WebformElementManager $plugin_webform */
       $plugin_webform = \Drupal::service('plugin.manager.webform.element');
       foreach ($plugin_webform->getInstances() as $id => $instance) {
@@ -36,16 +35,9 @@ class DefaultMaxlengthEnhancer extends ResourceFieldEnhancerBase {
         }
       }
       $this->updateElementsWithDefaultValue($types, $result);
-      \Drupal::cache()->set('webform_text_fields_default_maxlength', Yaml::encode($result));
+      \Drupal::cache()->set('webform_text_fields_default_maxlength', $result);
     }
     return $result;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function doTransform($data, Context $context) {
-    return $data;
   }
 
   /**

--- a/tests/behat/features/jsonapi.content_rating.feature
+++ b/tests/behat/features/jsonapi.content_rating.feature
@@ -15,6 +15,7 @@ Feature: JSON API Webform
     And the JSON node "data[0].attributes.elements.url" should exist
     And the JSON node "data[0].attributes.elements.was_this_page_helpful" should exist
     And the JSON node "data[0].attributes.elements.comments" should exist
+    And the JSON node "data[0].attributes.elements.comments.#maxlength" should be equal to "255"
 
   Scenario: Send POST request to the Content Rating form
     When I add "Content-Type" header equal to "application/vnd.api+json"

--- a/tide_webform.info.yml
+++ b/tide_webform.info.yml
@@ -10,6 +10,7 @@ dependencies:
   - webform:webform
   - webform:webform_ui
   - dpc-sdp:tide_core
+  - dpc-sdp:tide_api
 config_devel:
   install:
     - field.storage.node.field_show_content_rating

--- a/tide_webform.install
+++ b/tide_webform.install
@@ -376,3 +376,12 @@ function tide_webform_update_8016() {
     }
   }
 }
+
+/**
+ * Update elements enhancer to default_maxlength_enhancer.
+ */
+function tide_webform_update_8017() {
+  $config = \Drupal::configFactory()->getEditable('jsonapi_extras.jsonapi_resource_config.webform--webform');
+  $config->set('resourceFields.elements.enhancer.id', 'default_maxlength_enhancer');
+  $config->save();
+}

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -5,7 +5,9 @@
  * Tide Webform.
  */
 
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
@@ -13,8 +15,6 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\WebformSubmissionForm;
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Component\Utility\NestedArray;
 
 /**
  * Implements hook_config_ignore_settings_alter().

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -13,6 +13,8 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\WebformSubmissionForm;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Component\Utility\NestedArray;
 
 /**
  * Implements hook_config_ignore_settings_alter().
@@ -40,6 +42,27 @@ function tide_webform_form_alter(&$form, FormStateInterface $form_state, $form_i
   if ($form_id == 'webform_ui_element_form') {
     $form['#after_build'][] = 'tide_webform_webform_ui_element_form_after_build';
     $form['#attached']['library'][] = 'tide_webform/webform';
+    if (isset($form['properties']['form']['length_container']['maxlength']) && array_key_exists('#default_value', $form['properties']['form']['length_container']['maxlength'])) {
+      $default_value = NestedArray::getValue($form,
+        [
+          'properties',
+          'form',
+          'length_container',
+          'maxlength',
+          '#default_value',
+        ]);
+      if ($default_value === NULL) {
+        NestedArray::setValue($form,
+          [
+            'properties',
+            'form',
+            'length_container',
+            'maxlength',
+            '#default_value',
+          ],
+          '255');
+      }
+    }
   }
 
   if ($form_id == 'webform_submission_filter_form') {
@@ -392,4 +415,11 @@ function tide_webform_webform_element_default_properties_alter(array &$propertie
     $properties["counter_type"] = "character";
     $properties["counter_maximum"] = 255;
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function tide_webform_webform_update(EntityInterface $entity) {
+  \Drupal::cache()->invalidate('webform_text_fields_default_maxlength');
 }


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8012

### Change
1. Add a FieldEnhancer to expose default value to ripple
2. Add the default value to webforms.


example: 


```
                    "comments": {
                        "#type": "textarea",
                        "#title": "Any comments? (optional)",
                        "#rows": "2",
                        "#counter_type": "word",
                        "#counter_maximum": "500",
                        "#states": {
                            "visible": {
                                ":input[name=\"was_this_page_helpful\"]": {
                                    "checked": true
                                }
                            }
                        },
                        "#format_items": "comma",
                        "#maxlength": 255
                    },
```