### PR TITLE
Added sever side validation for empty required field submission.

### DIFF
--- a/tide_webform.module
+++ b/tide_webform.module
@@ -316,12 +316,18 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
   // See /Drupal/Core/Form/FormValidator.php $is_empty_value.
   $submission_data = $webform_submission->getData();
   foreach ($elements as $key => $element) {
+    // It will not validate for multi step form.
+    if ($element['#type'] == 'wizard_page') {
+      return;
+    }
     if ($element['#type'] == 'number') {
       if (is_numeric($submission_data[$key])) {
         $submission_data[$key] = strval($submission_data[$key]);
         $webform_submission->setData($submission_data);
       }
     }
+    // SDPAP-6627 temporary fix until contrib module patch is created.
+    // Look at webform issue - 3170790.
     // Server side validation from API submission.
     if ($element['#required'] == TRUE) {
       if (empty($submission_data[$key]) && $submission_data[$key] == "") {

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -317,10 +317,10 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
   $submission_data = $webform_submission->getData();
   foreach ($elements as $key => $element) {
     // It will not validate for multi step form.
-    if ($element['#type'] == 'wizard_page') {
+    if (isset($element['#type']) && $element['#type'] == 'wizard_page') {
       return;
     }
-    if ($element['#type'] == 'number') {
+    if (isset($element['#type']) && $element['#type'] == 'number') {
       if (is_numeric($submission_data[$key])) {
         $submission_data[$key] = strval($submission_data[$key]);
         $webform_submission->setData($submission_data);
@@ -330,7 +330,7 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
     // @todo: refactior the code and submit a patch.
     // Look at webform issue - 3170790.
     // Server side validation from API submission.
-    if ($element['#required'] == TRUE) {
+    if (isset($element['#required']) && $element['#required'] == TRUE) {
       if (empty($submission_data[$key]) && $submission_data[$key] == "") {
         // Throw an exception or return an error message to prevent saving the webform.
         throw new \Exception("The required field '{$element['#title']}' is empty.");

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -326,7 +326,7 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
     if ($element['#required'] == TRUE) {
       if (empty($submission_data[$key]) && $submission_data[$key] == "") {
         // Throw an exception or return an error message to prevent saving the webform.
-        throw new \Exception("The required field '{$element['#title']}' is empty oi j.");
+        throw new \Exception("The required field '{$element['#title']}' is empty.");
       }
     }
   }

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -322,6 +322,13 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
         $webform_submission->setData($submission_data);
       }
     }
+    // Server side validation from API submission.
+    if ($element['#required'] == TRUE) {
+      if (empty($submission_data[$key]) && $submission_data[$key] == "") {
+        // Throw an exception or return an error message to prevent saving the webform.
+        throw new \Exception("The required field '{$element['#title']}' is empty oi j.");
+      }
+    }
   }
   $errors = WebformSubmissionForm::validateWebformSubmission($webform_submission);
   if ($errors) {

--- a/tide_webform.module
+++ b/tide_webform.module
@@ -327,6 +327,7 @@ function tide_webform_webform_submission_presave(WebformSubmission $webform_subm
       }
     }
     // SDPAP-6627 temporary fix until contrib module patch is created.
+    // @todo: refactior the code and submit a patch.
     // Look at webform issue - 3170790.
     // Server side validation from API submission.
     if ($element['#required'] == TRUE) {


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-6627

### Issue 
If a field is mandatory, anyone can get the api submission curl from the FE and modify that to submit empty mandatory field. The webform module does not handles the server side validation well. There is an open issue but not much people can re produce the issue and it was closed. For a quick fix, going to add a custom validation in the tide_webform module.

### Related open issue to follow up 
https://www.drupal.org/project/webform/issues/3170790 -> the patch does not work, so will need to rework on this after opening the issue again.

### Changes
Added a custom server side validation to check if the required field value is empty or submitted as an empty string. If it is matches that then it will throw an exception instead saving the submission.

### Testing curl
1. You can copy the curl when a webform gets submitted from the FE and then modify the curl to put empty string for the mandatory field. Without this check it will submit, with this current change in this PR it will trow an exception.

`curl 'http://localhost:3000/api/tide/webform_submission/tide_webform_content_rating?site=8888' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'Connection: keep-alive' \
  -H 'Cookie: _ga=GA1.1.2139666398.1701043727; XDEBUG_SESSION=XDEBUG_ECLIPSE; _ga_0000000000=GS1.1.1714979753.6.1.1714979871.0.0.0' \
  -H 'Origin: http://localhost:3000' \
  -H 'Referer: http://localhost:3000/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36' \
  -H 'accept: application/json' \
  -H 'content-type: application/vnd.api+json;charset=UTF-8' \
  -H 'sec-ch-ua: "Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw '{"data":{"type":"webform_submission","attributes":{"remote_addr":"0.0.0.0","data":"{\"url\":\"http://localhost:3000/\",\"site_section_name\":\"Demo Section 2\",\"was_this_page_helpful\":\"\"}"}}}'`
### Screenshots
<img width="1278" alt="Screenshot 2024-05-06 at 7 18 20 PM" src="https://github.com/dpc-sdp/tide_webform/assets/20810541/74e43edd-e056-4423-be02-d6c2f3dafe17">
