### PR TITLE
[SDPAP-9170] Fixes webform downloading issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "extra": {
     "patches": {
       "drupal/webform": {
-        "Exporting webform submission as batch does not allowed for extended field due to static method - https://www.drupal.org/project/webform/issues/3348336#comment-14969352": "https://www.drupal.org/files/issues/2023-03-16/exporting-webform-submission-static-batch-process-3348336-3.patch"
+        "Exporting webform submission as batch does not allowed for extended field due to static method - https://www.drupal.org/project/webform/issues/3348336#comment-15686345": "https://www.drupal.org/files/issues/2024-07-24/exporting-webform-submission-static-batch-process-3348336-8.patch"
       }
     }
   },

--- a/src/TideWebformSubmissionExporter.php
+++ b/src/TideWebformSubmissionExporter.php
@@ -9,7 +9,6 @@ use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 use Drupal\user\Entity\User;
-use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\Plugin\WebformElementManagerInterface;
 use Drupal\webform\Plugin\WebformExporterManagerInterface;
 use Drupal\webform\WebformSubmissionExporter;
@@ -72,15 +71,14 @@ class TideWebformSubmissionExporter extends WebformSubmissionExporter {
     parent::generate();
     $export_options = $this->getExportOptions();
     $entity_ids = $this->getQuery()->execute();
-    if ($export_options['process_submissions']) {
-      $webform_submissions = WebformSubmission::loadMultiple($entity_ids);
-      foreach ($webform_submissions as $webform_submission) {
-        $processed_value = $webform_submission->processed->getValue()[0]['value'];
-        if ($processed_value == "0") {
-          $webform_submission->processed->setValue("1");
-          $webform_submission->save();
-        }
-      }
+    if (isset($export_options['process_submissions']) && $export_options['process_submissions'] == 1 && !empty($entity_ids)) {
+      \Drupal::database()->update('webform_submission')
+        ->fields(['processed' => 1])
+        ->condition('sid', $entity_ids, 'IN')
+        ->execute();
+      \Drupal::entityTypeManager()
+        ->getStorage('webform_submission')
+        ->resetCache($entity_ids);
     }
 
     $this->logExport($entity_ids, $export_options);


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-9170

### Change
Reroll the patch to use an SQL query instead of a Drupal entity query
 - https://www.drupal.org/project/webform/issues/3348336#comment-15686345

SQL queries for data updates can bypass entity checks. In our case, we have conditional **webform** fields that cannot undergo entity checks. This essentially means we have some required fields that cannot be filled.
